### PR TITLE
fix(tests): update tests for vLLM v0.12 API changes

### DIFF
--- a/tests/torch_compile/common/test_forward_context.py
+++ b/tests/torch_compile/common/test_forward_context.py
@@ -31,13 +31,16 @@ def attn_metadata_mock():
 def test_forward_context(vllm_config, attn_metadata_mock: MagicMock):
     # forward_context
     from vllm.forward_context import get_forward_context, set_forward_context
+
     with set_forward_context(
             attn_metadata_mock,
             vllm_config,
             num_tokens_across_dp=torch.tensor([0, 1]),
+            num_padded_tokens=1,
     ):
         # assert dp_metadata class name is RBLNDPMetadata
         assert (get_forward_context().dp_metadata.__class__.__name__ ==
-                "RBLNDPMetadata"
-                ), f"Expected 'dp_metadata' class name is RBLNDPMetadata, \
+                "RBLNDPMetadata"), (
+                    f"Expected 'dp_metadata' class name is RBLNDPMetadata, \
                     got {get_forward_context().dp_metadata.__class__.__name__}"
+                )

--- a/tests/torch_compile/common/test_platform.py
+++ b/tests/torch_compile/common/test_platform.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import torch
 
 
 def test_platform_plugins():
     import runpy
+
     current_file = __file__
     import os
+
     example_file = os.path.join(
         os.path.dirname(
             os.path.dirname(os.path.dirname(os.path.dirname(current_file)))),
@@ -30,48 +31,59 @@ def test_platform_plugins():
 
     # check if the plugin is loaded correctly
     from vllm.platforms import _init_trace, current_platform
+
     assert current_platform.plugin_name == "rbln", (
         f"Expected DummyDevice, got {current_platform.plugin_name}, "
         "possibly because current_platform is imported before the plugin"
         f" is loaded. The first import:\n{_init_trace}")
 
 
-def test_register_ops(monkeypatch: pytest.MonkeyPatch, vllm_config):
-    monkeypatch.setattr("vllm.config._current_vllm_config", vllm_config)
+def test_register_ops(vllm_config):
+    from vllm.config import set_current_vllm_config
 
-    # Attention
-    from vllm.attention.layer import Attention
-    attention = Attention(16, 32, 16, 16, prefix="layer.0")
-    assert hasattr(
-        attention, "layer_index"
-    ), f"Expected 'layer_index' in attention.__dict__, got {attention.__dict__}"
-    assert isinstance(
-        attention.layer_index, int
-    ), f"Expected 'layer_index' in attention.__dict__, got {attention.__dict__}"
-    assert (
-        attention.layer_index == 0
-    ), f"Expected 'layer_index' in attention.__dict__, got {attention.__dict__}"
+    with set_current_vllm_config(vllm_config):
+        # Attention
+        from vllm.attention.layer import Attention
 
-    # RotaryEmbedding
-    from vllm.model_executor.layers.rotary_embedding.base import (
-        RotaryEmbedding)
+        attention = Attention(16, 32, 16, 16, prefix="layer.0")
+        assert hasattr(
+            attention,
+            "layer_index"), ("Expected 'layer_index' in attention.__dict__,"
+                             f" got {attention.__dict__}")
+        assert isinstance(
+            attention.layer_index,
+            int), ("Expected 'layer_index' in attention.__dict__,"
+                   f" got {attention.__dict__}")
+        assert attention.layer_index == 0, (
+            "Expected 'layer_index' in attention.__dict__,"
+            f" got {attention.__dict__}")
 
-    rope = RotaryEmbedding(16, 16, 16, 16, True, torch.float16)
-    assert "rope_forward_oot" in str(rope.__dict__["_forward_method"]), (
-        f"Expected 'rope_forward_oot' in layer.__dict__['_forward_method'], \
-            got {rope.__dict__['_forward_method']}")
-    assert isinstance(rope.get_buffer("cos_cache"), torch.Tensor), (
-        f"Expected 'cos_cache' in buffer, got {rope.get_buffer('cos_cache')}")
-    assert isinstance(rope.get_buffer("sin_cache"), torch.Tensor), (
-        f"Expected 'sin_cache' in buffer, got {rope.get_buffer('sin_cache')}")
+        # RotaryEmbedding
+        from vllm.model_executor.layers.rotary_embedding.base import (
+            RotaryEmbedding)
+
+        rope = RotaryEmbedding(16, 16, 16, 16, True, torch.float16)
+        assert "rope_forward_oot" in str(rope.__dict__["_forward_method"]), (
+            f"Expected 'rope_forward_oot' in "
+            f"layer.__dict__['_forward_method'], "
+            f"got {rope.__dict__['_forward_method']}")
+        assert isinstance(
+            rope.get_buffer("cos_cache"),
+            torch.Tensor), (f"Expected 'cos_cache' in buffer, "
+                            f"got {rope.get_buffer('cos_cache')}")
+        assert isinstance(
+            rope.get_buffer("sin_cache"),
+            torch.Tensor), (f"Expected 'sin_cache' in buffer, "
+                            f"got {rope.get_buffer('sin_cache')}")
 
 
 def test_get_attn_backend_cls():
     from vllm_rbln.platform import RblnPlatform
+
     attn_backend_cls = RblnPlatform.get_attn_backend_cls(
         None, 16, torch.float16, None, 16, False, False, False)
     assert (
         attn_backend_cls ==
         "vllm_rbln.v1.attention.backends.flash_attention.RBLNAttentionBackend"
-    ), f"Expected 'vllm_rbln.attention.backends.flash_attention.\
-        RBLNAttentionBackend', got {attn_backend_cls}"
+    ), (f"Expected 'vllm_rbln.attention.backends.flash_attention.\
+        RBLNAttentionBackend', got {attn_backend_cls}")

--- a/tests/torch_compile/common/test_rbln_envs.py
+++ b/tests/torch_compile/common/test_rbln_envs.py
@@ -17,62 +17,62 @@ import vllm_rbln.rbln_envs as rbln_envs
 
 def test_rbln_envs():
     # check default values
-    assert (rbln_envs.VLLM_RBLN_COMPILE_MODEL
-            ), f"Expected VLLM_RBLN_COMPILE_MODEL to be True, \
-        got {rbln_envs.VLLM_RBLN_COMPILE_MODEL}"
+    assert rbln_envs.VLLM_RBLN_COMPILE_MODEL, (
+        f"Expected VLLM_RBLN_COMPILE_MODEL to be True, \
+        got {rbln_envs.VLLM_RBLN_COMPILE_MODEL}")
 
-    assert (not rbln_envs.VLLM_RBLN_COMPILE_STRICT_MODE
-            ), f"Expected VLLM_RBLN_COMPILE_STRICT_MODE to be False, \
-        got {rbln_envs.VLLM_RBLN_COMPILE_STRICT_MODE}"
+    assert not rbln_envs.VLLM_RBLN_COMPILE_STRICT_MODE, (
+        f"Expected VLLM_RBLN_COMPILE_STRICT_MODE to be False, \
+        got {rbln_envs.VLLM_RBLN_COMPILE_STRICT_MODE}")
 
-    assert (rbln_envs.VLLM_RBLN_TP_SIZE == 1
-            ), f"Expected VLLM_RBLN_TP_SIZE to be 1, \
-        got {rbln_envs.VLLM_RBLN_TP_SIZE}"
+    assert rbln_envs.VLLM_RBLN_TP_SIZE == 1, (
+        f"Expected VLLM_RBLN_TP_SIZE to be 1, \
+        got {rbln_envs.VLLM_RBLN_TP_SIZE}")
 
-    assert (rbln_envs.VLLM_RBLN_SAMPLER
-            ), f"Expected VLLM_RBLN_SAMPLER to be True, \
-        got {rbln_envs.VLLM_RBLN_SAMPLER}"
+    assert rbln_envs.VLLM_RBLN_SAMPLER, (
+        f"Expected VLLM_RBLN_SAMPLER to be True, \
+        got {rbln_envs.VLLM_RBLN_SAMPLER}")
 
-    assert (rbln_envs.VLLM_RBLN_ENABLE_WARM_UP
-            ), f"Expected VLLM_RBLN_ENABLE_WARM_UP to be True, \
-        got {rbln_envs.VLLM_RBLN_ENABLE_WARM_UP}"
+    assert rbln_envs.VLLM_RBLN_ENABLE_WARM_UP, (
+        f"Expected VLLM_RBLN_ENABLE_WARM_UP to be True, \
+        got {rbln_envs.VLLM_RBLN_ENABLE_WARM_UP}")
 
-    assert (rbln_envs.VLLM_RBLN_USE_VLLM_MODEL
-            ), f"Expected VLLM_RBLN_USE_VLLM_MODEL to be True, \
-        got {rbln_envs.VLLM_RBLN_USE_VLLM_MODEL}"
+    assert rbln_envs.VLLM_RBLN_USE_VLLM_MODEL, (
+        f"Expected VLLM_RBLN_USE_VLLM_MODEL to be True, \
+        got {rbln_envs.VLLM_RBLN_USE_VLLM_MODEL}")
 
-    assert (rbln_envs.VLLM_RBLN_FLASH_CAUSAL_ATTN
-            ), f"Expected VLLM_RBLN_FLASH_CAUSAL_ATTN to be True, \
-        got {rbln_envs.VLLM_RBLN_FLASH_CAUSAL_ATTN}"
+    assert rbln_envs.VLLM_RBLN_FLASH_CAUSAL_ATTN, (
+        f"Expected VLLM_RBLN_FLASH_CAUSAL_ATTN to be True, \
+        got {rbln_envs.VLLM_RBLN_FLASH_CAUSAL_ATTN}")
 
-    assert (not rbln_envs.VLLM_RBLN_DISABLE_MM
-            ), f"Expected VLLM_RBLN_DISABLE_MM to be False, \
-        got {rbln_envs.VLLM_RBLN_DISABLE_MM}"
+    assert not rbln_envs.VLLM_RBLN_DISABLE_MM, (
+        f"Expected VLLM_RBLN_DISABLE_MM to be False, \
+        got {rbln_envs.VLLM_RBLN_DISABLE_MM}")
 
-    assert (rbln_envs.VLLM_RBLN_DP_IMPL == "dummy_prefill"
-            ), f"Expected VLLM_RBLN_DP_IMPL to be dummy_prefill, \
-        got {rbln_envs.VLLM_RBLN_DP_IMPL}"
+    assert rbln_envs.VLLM_RBLN_DP_IMPL == "padded_decode", (
+        f"Expected VLLM_RBLN_DP_IMPL to be padded_decode, \
+        got {rbln_envs.VLLM_RBLN_DP_IMPL}")
 
-    assert (not rbln_envs.VLLM_RBLN_ENFORCE_MODEL_FP32
-            ), f"Expected VLLM_RBLN_ENFORCE_MODEL_FP32 to be False, \
-        got {rbln_envs.VLLM_RBLN_ENFORCE_MODEL_FP32}"
+    assert not rbln_envs.VLLM_RBLN_ENFORCE_MODEL_FP32, (
+        f"Expected VLLM_RBLN_ENFORCE_MODEL_FP32 to be False, \
+        got {rbln_envs.VLLM_RBLN_ENFORCE_MODEL_FP32}")
 
-    assert (rbln_envs.VLLM_RBLN_MOE_CUSTOM_KERNEL
-            ), f"Expected VLLM_RBLN_MOE_CUSTOM_KERNEL to be True, \
-        got {rbln_envs.VLLM_RBLN_MOE_CUSTOM_KERNEL}"
+    assert rbln_envs.VLLM_RBLN_MOE_CUSTOM_KERNEL, (
+        f"Expected VLLM_RBLN_MOE_CUSTOM_KERNEL to be True, \
+        got {rbln_envs.VLLM_RBLN_MOE_CUSTOM_KERNEL}")
 
-    assert (rbln_envs.VLLM_RBLN_DP_INPUT_ALL_GATHER
-            ), f"Expected VLLM_RBLN_DP_INPUT_ALL_GATHER to be True, \
-        got {rbln_envs.VLLM_RBLN_DP_INPUT_ALL_GATHER}"
+    assert rbln_envs.VLLM_RBLN_DP_INPUT_ALL_GATHER, (
+        f"Expected VLLM_RBLN_DP_INPUT_ALL_GATHER to be True, \
+        got {rbln_envs.VLLM_RBLN_DP_INPUT_ALL_GATHER}")
 
-    assert (rbln_envs.VLLM_RBLN_LOGITS_ALL_GATHER
-            ), f"Expected VLLM_RBLN_LOGITS_ALL_GATHER to be True, \
-        got {rbln_envs.VLLM_RBLN_LOGITS_ALL_GATHER}"
+    assert rbln_envs.VLLM_RBLN_LOGITS_ALL_GATHER, (
+        f"Expected VLLM_RBLN_LOGITS_ALL_GATHER to be True, \
+        got {rbln_envs.VLLM_RBLN_LOGITS_ALL_GATHER}")
 
-    assert (rbln_envs.VLLM_RBLN_NUM_RAY_NODES == 1
-            ), f"Expected VLLM_RBLN_NUM_RAY_NODES to be 1, \
-        got {rbln_envs.VLLM_RBLN_NUM_RAY_NODES}"
+    assert rbln_envs.VLLM_RBLN_NUM_RAY_NODES == 1, (
+        f"Expected VLLM_RBLN_NUM_RAY_NODES to be 1, \
+        got {rbln_envs.VLLM_RBLN_NUM_RAY_NODES}")
 
-    assert (not rbln_envs.VLLM_RBLN_METRICS
-            ), f"Expected VLLM_RBLN_METRICS to be False, \
-        got {rbln_envs.VLLM_RBLN_METRICS}"
+    assert not rbln_envs.VLLM_RBLN_METRICS, (
+        f"Expected VLLM_RBLN_METRICS to be False, \
+        got {rbln_envs.VLLM_RBLN_METRICS}")

--- a/tests/torch_compile/conftest.py
+++ b/tests/torch_compile/conftest.py
@@ -29,7 +29,7 @@ def initialize_environment():
 
 @pytest.fixture
 def vllm_config():
-    scheduler_config = SchedulerConfig()
+    scheduler_config = SchedulerConfig.default_factory()
     model_config = ModelConfig(model="facebook/opt-125m")
     cache_config = CacheConfig(
         block_size=1024,

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -16,7 +16,7 @@ import pytest
 import torch
 from vllm import SamplingParams
 from vllm.platforms import current_platform
-from vllm.utils import sha256
+from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import (get_request_block_hasher,
                                          init_none_hash)
 from vllm.v1.request import Request, RequestStatus
@@ -118,9 +118,12 @@ def create_request(
         ),
     ],
 )
-def test_prefix_cache_hit_same_prompt(scheduler, token_length: int,
-                                      cached_block_table: list[int],
-                                      cached_length: list[int]):
+def test_prefix_cache_hit_same_prompt(
+    scheduler,
+    token_length: int,
+    cached_block_table: list[int],
+    cached_length: list[int],
+):
     init_none_hash(HASH_FN)
     """
     Check the prefix caching works as expected
@@ -158,22 +161,29 @@ def test_prefix_cache_hit_same_prompt(scheduler, token_length: int,
     assert output.cached_length == cached_length
 
 
-@pytest.mark.parametrize("token_length, decode_steps, allocated_blocks", [
-    pytest.param(
-        31,
-        1,
-        [0, 1, 2, -1],
-        id="decode_1_step_and_eviction",
-    ),
-    pytest.param(
-        25,
-        7,
-        [0, 1, 2, -1],
-        id="decode_7_steps_eviction",
-    ),
-])
-def test_eviction(limited_4blocks_scheduler, token_length: int,
-                  decode_steps: int, allocated_blocks: list[int]):
+@pytest.mark.parametrize(
+    "token_length, decode_steps, allocated_blocks",
+    [
+        pytest.param(
+            31,
+            1,
+            [0, 1, 2, -1],
+            id="decode_1_step_and_eviction",
+        ),
+        pytest.param(
+            25,
+            7,
+            [0, 1, 2, -1],
+            id="decode_7_steps_eviction",
+        ),
+    ],
+)
+def test_eviction(
+    limited_4blocks_scheduler,
+    token_length: int,
+    decode_steps: int,
+    allocated_blocks: list[int],
+):
     init_none_hash(HASH_FN)
     """
     Check the eviction works as expected.

--- a/tests/v1/core/test_structured_output.py
+++ b/tests/v1/core/test_structured_output.py
@@ -34,12 +34,18 @@ def test_structured_output():
 
     # Prefill 1st request
     scheduler_output = scheduler.schedule()
-    assert len(scheduler_output.structured_output_request_ids) == 1
-    assert len(scheduler_output.grammar_bitmask) == 1
+    grammar_output = scheduler.get_grammar_bitmask(scheduler_output)
+    assert grammar_output is not None
+    assert len(grammar_output.structured_output_request_ids) == 1
+    assert len(grammar_output.grammar_bitmask) == 1
     # Prefill 2nd request
     scheduler_output = scheduler.schedule()
-    assert len(scheduler_output.structured_output_request_ids) == 1
-    assert len(scheduler_output.grammar_bitmask) == 1
+    grammar_output = scheduler.get_grammar_bitmask(scheduler_output)
+    assert grammar_output is not None
+    assert len(grammar_output.structured_output_request_ids) == 1
+    assert len(grammar_output.grammar_bitmask) == 1
     # Decode step for both requests
     scheduler_output = scheduler.schedule()
-    assert len(scheduler_output.structured_output_request_ids) == 2
+    grammar_output = scheduler.get_grammar_bitmask(scheduler_output)
+    assert grammar_output is not None
+    assert len(grammar_output.structured_output_request_ids) == 2

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -18,8 +18,8 @@ import torch
 from vllm.config import CacheConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.multimodal.inputs import (MultiModalFeatureSpec,
                                     MultiModalKwargsItem, PlaceholderRange)
-from vllm.sampling_params import GuidedDecodingParams, SamplingParams
-from vllm.utils import sha256
+from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.utils.hashing import sha256
 from vllm.v1.core.kv_cache_utils import (get_request_block_hasher,
                                          init_none_hash)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -27,11 +27,10 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
 from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
-from vllm.v1.structured_output.request import StructuredOutputRequest
 
-from vllm_rbln.core.scheduler import RBLNScheduler
 from vllm_rbln.v1.core.optimum_scheduler import (RBLNOptimumScheduler,
                                                  RBLNSchedulerOutput)
+from vllm_rbln.v1.core.rbln_scheduler import RBLNScheduler
 
 EOS_TOKEN_ID = 50256
 _none_hash_initialized = False
@@ -63,17 +62,18 @@ def create_scheduler(
     if max_model_len is None:
         max_model_len = max_num_batched_tokens
 
-    scheduler_config = SchedulerConfig(
-        max_num_seqs=max_num_seqs,
-        max_num_batched_tokens=max_num_batched_tokens,
-        max_model_len=max_model_len,
-        async_scheduling=async_scheduling,
-    )
     model_config = ModelConfig(
         model=model,
         trust_remote_code=True,
         dtype=torch.float,
         seed=42,
+    )
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=max_num_seqs,
+        max_num_batched_tokens=max_num_batched_tokens,
+        max_model_len=max_model_len,
+        async_scheduling=async_scheduling,
+        is_encoder_decoder=model_config.is_encoder_decoder,
     )
     # Cache config
     cache_config = CacheConfig(
@@ -131,15 +131,16 @@ def create_requests(
 
     block_hasher = get_request_block_hasher(block_size, sha256)
     if sample_json_schema:
-        guided_decoding = GuidedDecodingParams(json=sample_json_schema,
-                                               backend="xgrammar")
+        structured_outputs = StructuredOutputsParams(json=sample_json_schema)
     else:
-        guided_decoding = None
-    sampling_params = SamplingParams(ignore_eos=False,
-                                     max_tokens=max_tokens,
-                                     stop_token_ids=stop_token_ids,
-                                     prompt_logprobs=prompt_logprobs,
-                                     guided_decoding=guided_decoding)
+        structured_outputs = None
+    sampling_params = SamplingParams(
+        ignore_eos=False,
+        max_tokens=max_tokens,
+        stop_token_ids=stop_token_ids,
+        prompt_logprobs=prompt_logprobs,
+        structured_outputs=structured_outputs,
+    )
     requests = []
     for i in range(num_requests):
         mm_features = []
@@ -153,20 +154,21 @@ def create_requests(
                     data=MultiModalKwargsItem.dummy("dummy_m"),
                     mm_position=position,
                     identifier=identifier,
-                    modality="image")
+                    modality="image",
+                )
                 mm_features.append(mm_feature)
 
-        prompt_token_ids = ([0] * num_tokens if same_prompt else [i] *
-                            num_tokens)
-        request = Request(request_id=f"{i}",
-                          prompt_token_ids=prompt_token_ids,
-                          sampling_params=sampling_params,
-                          pooling_params=None,
-                          mm_features=mm_features if mm_features else None,
-                          eos_token_id=EOS_TOKEN_ID,
-                          block_hasher=block_hasher,
-                          structured_output_request=StructuredOutputRequest(
-                              sampling_params=sampling_params))
+        prompt_token_ids = [0] * num_tokens if same_prompt else [i
+                                                                 ] * num_tokens
+        request = Request(
+            request_id=f"{i}",
+            prompt_token_ids=prompt_token_ids,
+            sampling_params=sampling_params,
+            pooling_params=None,
+            mm_features=mm_features if mm_features else None,
+            eos_token_id=EOS_TOKEN_ID,
+            block_hasher=block_hasher,
+        )
         requests.append(request)
     return requests
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -67,6 +67,7 @@ def create_scheduler(
         trust_remote_code=True,
         dtype=torch.float,
         seed=42,
+        max_model_len=max_model_len,
     )
     scheduler_config = SchedulerConfig(
         max_num_seqs=max_num_seqs,
@@ -132,6 +133,9 @@ def create_requests(
     block_hasher = get_request_block_hasher(block_size, sha256)
     if sample_json_schema:
         structured_outputs = StructuredOutputsParams(json=sample_json_schema)
+        # In v0.12, _backend is set by Processor._validate_structured_output
+        # at request time. In tests, we set it manually.
+        structured_outputs._backend = "xgrammar"
     else:
         structured_outputs = None
     sampling_params = SamplingParams(

--- a/vllm_rbln/v1/core/optimum_kv_cache_manager.py
+++ b/vllm_rbln/v1/core/optimum_kv_cache_manager.py
@@ -44,14 +44,19 @@ class RBLNKVCacheManager(KVCacheManager):
         PrefixKVCacheManager manages the mapping
         between inner blocks and outer blocks for prefix caching.
         """
+        # In upstream v0.12, KVCacheManager no longer stores block_size
+        # as an instance attribute and requires hash_block_size param.
+        self.block_size = kv_cache_config.kv_cache_groups[
+            0].kv_cache_spec.block_size
         super().__init__(
             kv_cache_config,
             max_model_len,
-            enable_caching,
-            use_eagle,
-            log_stats,
-            enable_kv_cache_events,
-            dcp_world_size,
+            hash_block_size=self.block_size,
+            enable_caching=enable_caching,
+            use_eagle=use_eagle,
+            log_stats=log_stats,
+            enable_kv_cache_events=enable_kv_cache_events,
+            dcp_world_size=dcp_world_size,
         )
         if enable_caching:
             self.prefix_cache_manager = RBLNPrefixKVCacheManager(
@@ -63,8 +68,7 @@ class RBLNKVCacheManager(KVCacheManager):
             )
 
     def free(self, request: Request, preemption: int = False) -> None:
-        """Free the blocks allocated for the request.
-        """
+        """Free the blocks allocated for the request."""
         if self.enable_caching:
             self.prefix_cache_manager.free_request(request.request_id,
                                                    preemption=preemption)
@@ -104,7 +108,7 @@ class RBLNKVCacheManager(KVCacheManager):
         # In decode,
         # `num_computed_tokens` = the length of prompt + generated text
         # `num_new_tokens` = 1.
-        is_prefill = (request.num_computed_tokens == 0)
+        is_prefill = request.num_computed_tokens == 0
         num_computed_tokens = request.num_computed_tokens
         num_tokens_need_slot = min(request.num_tokens, self.max_model_len)
         num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
@@ -135,11 +139,10 @@ class RBLNKVCacheManager(KVCacheManager):
         #         self.block_pool.get_num_free_blocks():
         #         return None
 
-        if self.enable_caching and \
-            not self.prefix_cache_manager.can_allocate(
-                    num_blocks_to_allocate,
-                    num_computed_tokens,
-            ):
+        if self.enable_caching and not self.prefix_cache_manager.can_allocate(
+                num_blocks_to_allocate,
+                num_computed_tokens,
+        ):
             # Cannot allocate new outer blocks for prefix caching
             return None
 
@@ -218,11 +221,12 @@ class RBLNKVCacheManager(KVCacheManager):
         num_new_computed_tokens: int,
     ) -> tuple[list[int], list[int]]:
         cached_blocks = new_computed_blocks.get_block_ids()[0]
-        cached_block_table, cached_length = \
+        cached_block_table, cached_length = (
             self.prefix_cache_manager.get_matched_outer_blocks(
-            request.request_id, cached_blocks,
-            num_new_computed_tokens,
-        )
+                request.request_id,
+                cached_blocks,
+                num_new_computed_tokens,
+            ))
 
         return cached_block_table, cached_length
 

--- a/vllm_rbln/v1/core/optimum_scheduler.py
+++ b/vllm_rbln/v1/core/optimum_scheduler.py
@@ -52,6 +52,7 @@ class RBLNSchedulerOutput(SchedulerOutput):
         if the number of requests is less than the number of batch_size
         in decode phase.
     """
+
     block_table_dict: dict[str, torch.Tensor] = None
     cached_block_table: list[int] = field(default_factory=list)
     cached_length: list[int] = field(default_factory=list)
@@ -89,12 +90,16 @@ class RBLNOptimumScheduler(Scheduler):
 
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
-        self.max_num_scheduled_tokens = \
-            self.scheduler_config.max_num_batched_tokens
-        self.max_model_len = self.scheduler_config.max_model_len
+        self.max_num_scheduled_tokens = (
+            self.scheduler_config.max_num_batched_tokens)
+        self.max_model_len = vllm_config.model_config.max_model_len
         # KVConnector and KVEventPublisher is not used in RBLN.
         self.connector = None
+        self.connector_prefix_cache_stats = None
         self.kv_event_publisher = None
+        self.ec_connector = None
+        self.kv_metrics_collector = None
+        self.failed_recving_kv_req_ids: set[str] = set()
         num_gpu_blocks = self.cache_config.num_gpu_blocks
         assert num_gpu_blocks is not None and num_gpu_blocks > 0
 
@@ -127,8 +132,8 @@ class RBLNOptimumScheduler(Scheduler):
         self.encoder_cache_manager = EncoderCacheManager(cache_size=0)
 
         # Create the KV cache manager.
-        if self.vllm_config.additional_config is not None \
-            and "attn_block_size" in self.vllm_config.additional_config:
+        if (self.vllm_config.additional_config is not None
+                and "attn_block_size" in self.vllm_config.additional_config):
             attn_block_size = self.vllm_config.additional_config[
                 "attn_block_size"]
         else:
@@ -145,6 +150,7 @@ class RBLNOptimumScheduler(Scheduler):
             max_num_seqs=self.max_num_running_reqs,
         )
 
+        self.prev_step_scheduled_req_ids: set[str] = set()
         self.use_pp = False
 
     def schedule(self) -> RBLNSchedulerOutput:
@@ -234,9 +240,8 @@ class RBLNOptimumScheduler(Scheduler):
 
                 assert request.num_computed_tokens == 0
                 # Get locally-cached tokens.
-                new_computed_blocks, num_new_local_computed_tokens = \
-                    self.kv_cache_manager.get_computed_blocks(
-                        request)
+                new_computed_blocks, num_new_local_computed_tokens = (
+                    self.kv_cache_manager.get_computed_blocks(request))
 
                 # Number of tokens to be scheduled.
                 # We use `request.num_tokens` instead of
@@ -318,7 +323,8 @@ class RBLNOptimumScheduler(Scheduler):
                 # This is necessary when using spec decoding.
                 num_new_tokens = min(
                     num_new_tokens,
-                    self.max_model_len - 1 - request.num_computed_tokens)
+                    self.max_model_len - 1 - request.num_computed_tokens,
+                )
 
                 if num_new_tokens == 0:
                     # The request cannot be scheduled
@@ -363,13 +369,16 @@ class RBLNOptimumScheduler(Scheduler):
                             ]
                         logger.warning(
                             "Request %s is preempted. Freed block(s): %s",
-                            preempted_req.request_id, preempted_blocks)
+                            preempted_req.request_id,
+                            preempted_blocks,
+                        )
                         preempted_req.status = RequestStatus.PREEMPTED
                         preempted_req.num_computed_tokens = 0
                         if self.log_stats:
                             preempted_req.record_event(
                                 EngineCoreEventType.PREEMPTED,
-                                scheduled_timestamp)
+                                scheduled_timestamp,
+                            )
 
                         self.waiting.prepend_request(preempted_req)
                         preempted_reqs.append(preempted_req)
@@ -403,8 +412,8 @@ class RBLNOptimumScheduler(Scheduler):
         # Since some requests in the RUNNING queue may not be scheduled in
         # this step, the total number of scheduled requests can be smaller than
         # len(self.running).
-        assert (len(scheduled_new_reqs) + len(scheduled_resumed_reqs) +
-                len(scheduled_running_reqs) <= len(self.running))
+        assert len(scheduled_new_reqs) + len(scheduled_resumed_reqs) + len(
+            scheduled_running_reqs) <= len(self.running)
 
         # Get the longest common prefix among all requests in the running queue.
         # This can be potentially used for cascade attention.
@@ -414,7 +423,7 @@ class RBLNOptimumScheduler(Scheduler):
             any_request = self.running[0]
             num_common_prefix_blocks = (
                 self.kv_cache_manager.get_num_common_prefix_blocks(
-                    any_request, len(self.running)))
+                    any_request.request_id))
 
         # Construct the scheduler output.
         new_reqs_data = [
@@ -430,17 +439,16 @@ class RBLNOptimumScheduler(Scheduler):
             scheduled_spec_decode_tokens,
             req_to_new_blocks,
         )
-        structured_output_request_ids, grammar_bitmask = (
-            self.get_grammar_bitmask(
-                scheduled_new_reqs + scheduled_running_reqs,
-                scheduled_spec_decode_tokens))
-
         # Calculate the dummy block index.
         if self.cache_config.enable_prefix_caching:
             num_decode_reqs = len(scheduled_running_reqs)
-            if num_decode_reqs > 0 and \
-                num_decode_reqs < self.max_num_running_reqs:
+            if (num_decode_reqs > 0
+                    and num_decode_reqs < self.max_num_running_reqs):
                 dummy_block = self.kv_cache_manager.get_dummy_block()
+
+        # Record the request ids that were scheduled in this step.
+        self.prev_step_scheduled_req_ids.clear()
+        self.prev_step_scheduled_req_ids.update(num_scheduled_tokens.keys())
 
         scheduler_output = RBLNSchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
@@ -450,14 +458,14 @@ class RBLNOptimumScheduler(Scheduler):
             scheduled_spec_decode_tokens=scheduled_spec_decode_tokens,
             scheduled_encoder_inputs=None,
             num_common_prefix_blocks=num_common_prefix_blocks,
+            preempted_req_ids={req.request_id
+                               for req in preempted_reqs},
             # finished_req_ids is an existing state in the scheduler,
             # instead of being newly scheduled in this step.
             # It contains the request IDs that are finished in between
             # the previous and the current steps.
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=[],
-            structured_output_request_ids=structured_output_request_ids,
-            grammar_bitmask=grammar_bitmask,
             block_table_dict=block_table_dict,
             cached_block_table=cached_block_table,
             cached_length=cached_length,


### PR DESCRIPTION
## Summary

Fix pre-existing test failures caused by vLLM v0.12 API changes that were not updated when the codebase was bumped to v0.12. All 28 tests now pass.

## Changes

### Source fixes

#### `vllm_rbln/v1/core/optimum_scheduler.py`
- `self.scheduler_config.max_model_len` → `vllm_config.model_config.max_model_len` (v0.12 `SchedulerConfig.max_model_len` is `InitVar`, not stored)
- `get_num_common_prefix_blocks(request, count)` → `get_num_common_prefix_blocks(request_id)` (signature changed)
- Remove `get_grammar_bitmask()` call from `schedule()` — grammar output is now a separate `GrammarOutput` object produced after `SchedulerOutput` construction
- Remove `structured_output_request_ids` and `grammar_bitmask` from `RBLNSchedulerOutput` constructor (fields moved to `GrammarOutput`)
- Add `preempted_req_ids` to `RBLNSchedulerOutput` constructor (new upstream field)
- Add `prev_step_scheduled_req_ids` tracking before `_update_after_schedule()`
- Add missing attrs from upstream `Scheduler.__init__`: `connector_prefix_cache_stats`, `kv_metrics_collector`, `ec_connector`, `failed_recving_kv_req_ids`

#### `vllm_rbln/v1/core/optimum_kv_cache_manager.py`
- Pass `hash_block_size=self.block_size` to `super().__init__()` (new required param in v0.12)
- Explicitly store `self.block_size` from `kv_cache_config` (no longer set by parent)

### Test fixes

#### `tests/torch_compile/conftest.py`
- `SchedulerConfig()` → `SchedulerConfig.default_factory()`

#### `tests/torch_compile/common/test_rbln_envs.py`
- Fix expected `VLLM_RBLN_DP_IMPL` default: `"dummy_prefill"` → `"padded_decode"`

#### `tests/torch_compile/common/test_platform.py`
- `monkeypatch.setattr("vllm.config._current_vllm_config", ...)` → `set_current_vllm_config()` context manager

#### `tests/torch_compile/common/test_forward_context.py`
- Add `num_padded_tokens=1` to `set_forward_context()` call (required by `RBLNDPMetadata.make` assertion)

#### `tests/v1/core/test_prefix_caching.py`
- `from vllm.utils import sha256` → `from vllm.utils.hashing import sha256`

#### `tests/v1/core/test_structured_output.py`
- Update to new `get_grammar_bitmask(scheduler_output)` → `GrammarOutput` API

#### `tests/v1/core/utils.py`
- `GuidedDecodingParams` → `StructuredOutputsParams`, update `SamplingParams` field name
- `from vllm.utils import sha256` → `from vllm.utils.hashing import sha256`
- Fix `SchedulerConfig` and `Request` construction for v0.12
- Pass `max_model_len` to `ModelConfig` (consistent with `SchedulerConfig`)
- Set `StructuredOutputsParams._backend = "xgrammar"` (no longer auto-resolved in tests)

## Test Results

| Test Suite | Before | After |
|---|---|---|
| `tests/torch_compile/common/` (6 tests) | ❌ 4 failed | ✅ 6/6 passed |
| `tests/v1/core/` (22 tests) | ❌ 22 failed | ✅ 22/22 passed |
| **Total** | **26 failed** | **28/28 passed** ✅ |