### PR TITLE
feat(worker): chunked pipeline parallelism (CPP) with async P2P send

### DIFF
--- a/examples/experimental/test_cpp.py
+++ b/examples/experimental/test_cpp.py
@@ -58,7 +58,8 @@ import time
 
 def parse_args():
     p = argparse.ArgumentParser(
-        description="CPP (Chunked Pipeline Parallelism) test & benchmark")
+        description="CPP (Chunked Pipeline Parallelism) test & benchmark"
+    )
     p.add_argument("--model", type=str, default="meta-llama/Llama-3.2-1B")
     p.add_argument("--pp", type=int, default=2, help="pipeline_parallel_size")
     p.add_argument("--tp", type=int, default=1, help="tensor_parallel_size")
@@ -76,6 +77,12 @@ def parse_args():
         help="Chunk size for chunked prefill",
     )
     p.add_argument("--block-size", type=int, default=1024)
+    p.add_argument(
+        "--gpu-memory-utilization",
+        type=float,
+        default=0.8,
+        help="Fraction of device memory for KV cache (lower to avoid OOM)",
+    )
 
     # Test modes
     p.add_argument(
@@ -83,9 +90,9 @@ def parse_args():
         action="store_true",
         help="Run correctness test (PP=1 vs PP=N)",
     )
-    p.add_argument("--benchmark",
-                   action="store_true",
-                   help="Run performance benchmark")
+    p.add_argument(
+        "--benchmark", action="store_true", help="Run performance benchmark"
+    )
 
     # Benchmark parameters
     p.add_argument("--num-requests", type=int, default=32)
@@ -110,7 +117,7 @@ def build_llm(args, pp_override=None):
         pipeline_parallel_size=pp,
         enable_chunked_prefill=True,
         enable_prefix_caching=False,
-        gpu_memory_utilization=1.0,
+        gpu_memory_utilization=args.gpu_memory_utilization,
         trust_remote_code=True,
     )
 
@@ -118,12 +125,12 @@ def build_llm(args, pp_override=None):
 def make_prompts(num_requests, input_len):
     """Build deterministic prompts with exactly *input_len* tokens each.
 
-    Returns token-ID lists (prompt_token_ids) to guarantee exact length,
-    avoiding encode/decode round-trip mismatches.
+    Returns a list of ``TokensPrompt`` dicts compatible with ``LLM.generate()``,
+    guaranteeing exact token length without encode/decode round-trip mismatches.
     """
     # Token ID 1 is a safe dummy in most tokenizers.
     prompt_ids = [1] * input_len
-    return [prompt_ids] * num_requests
+    return [{"prompt_token_ids": prompt_ids} for _ in range(num_requests)]
 
 
 # -----------------------------------------------------------------------
@@ -188,11 +195,12 @@ def run_benchmark(args):
     from vllm import SamplingParams
 
     print("=" * 60)
-    print(f"Benchmark: PP={args.pp}  chunk={args.max_num_batched_tokens}  "
-          f"requests={args.num_requests}  in={args.input_len}  "
-          f"out={args.output_len}")
     print(
-        f"  async_pp_send = {os.environ.get('VLLM_RBLN_ASYNC_PP_SEND', '1')}")
+        f"Benchmark: PP={args.pp}  chunk={args.max_num_batched_tokens}  "
+        f"requests={args.num_requests}  in={args.input_len}  "
+        f"out={args.output_len}"
+    )
+    print(f"  async_pp_send = {os.environ.get('VLLM_RBLN_ASYNC_PP_SEND', '1')}")
     print("=" * 60)
 
     prompt_ids = make_prompts(args.num_requests, args.input_len)
@@ -208,16 +216,14 @@ def run_benchmark(args):
     # Warmup
     print(f"\nWarmup ({args.warmup_requests} requests) ...")
     _ = llm.generate(
-        prompt_token_ids=prompt_ids[:min(len(prompt_ids), args.warmup_requests
-                                         )],
+        prompts=prompt_ids[: min(len(prompt_ids), args.warmup_requests)],
         sampling_params=sampling,
     )
 
     # Timed run
     print("Timed run ...")
     t0 = time.perf_counter()
-    outputs = llm.generate(prompt_token_ids=prompt_ids,
-                           sampling_params=sampling)
+    outputs = llm.generate(prompts=prompt_ids, sampling_params=sampling)
     elapsed = time.perf_counter() - t0
 
     # Validate output shapes
@@ -226,12 +232,15 @@ def run_benchmark(args):
     ]
     output_lens = [len(o.outputs[0].token_ids) for o in outputs]
     if any(l != args.input_len for l in input_lens):
-        print(f"  WARNING: Input length mismatch. Expected {args.input_len}, "
-              f"got {set(input_lens)}")
+        print(
+            f"  WARNING: Input length mismatch. Expected {args.input_len}, "
+            f"got {set(input_lens)}"
+        )
     if any(l != args.output_len for l in output_lens):
         print(
             f"  WARNING: Output length mismatch. Expected {args.output_len}, "
-            f"got {set(output_lens)}")
+            f"got {set(output_lens)}"
+        )
 
     total_input_tokens = args.num_requests * args.input_len
     total_output_tokens = args.num_requests * args.output_len
@@ -240,8 +249,10 @@ def run_benchmark(args):
     print(f"  Total time:           {elapsed:.2f} s")
     print(f"  Prefill throughput:   {total_input_tokens / elapsed:.0f} tok/s")
     print(f"  Decode throughput:    {total_output_tokens / elapsed:.0f} tok/s")
-    print(f"  Total throughput:     "
-          f"{(total_input_tokens + total_output_tokens) / elapsed:.0f} tok/s")
+    print(
+        f"  Total throughput:     "
+        f"{(total_input_tokens + total_output_tokens) / elapsed:.0f} tok/s"
+    )
     print(f"  Requests/sec:         {args.num_requests / elapsed:.2f}")
 
     del llm
@@ -260,8 +271,10 @@ def main():
     args = parse_args()
 
     if not args.correctness and not args.benchmark:
-        print("Specify --correctness and/or --benchmark. "
-              "Running both by default.\n")
+        print(
+            "Specify --correctness and/or --benchmark. "
+            "Running both by default.\n"
+        )
         args.correctness = True
         args.benchmark = True
 

--- a/examples/experimental/test_cpp.py
+++ b/examples/experimental/test_cpp.py
@@ -1,0 +1,278 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ruff: noqa
+"""Chunked Pipeline Parallelism (CPP) — correctness & performance test.
+
+This script validates that pipeline-parallel execution with chunked prefill
+produces correct results, and measures the performance benefit of async P2P
+(the CPP optimisation).
+
+Prerequisites
+-------------
+* ``VLLM_RBLN_USE_VLLM_MODEL=1`` (V1 RBLN path, required for PP > 1)
+* ``VLLM_USE_V1=1``
+* ``VLLM_RBLN_BATCH_ATTN_OPT=1`` — required for the RBLN compiler to
+  compile decode graphs. Without this the compiler receives per-partition
+  seq_lens (shape ``[B, num_partition]``) instead of per-batch seq_idx
+  (shape ``[B, 1]``) and fails with
+  ``"Batch decode requires seq shape [B, 1], got (B, num_partition)"``.
+
+Known limitations
+-----------------
+* The RBLN batch-decode kernel has a compiler bug at
+  ``batch_bucket_size=4``. Avoid ``max_num_seqs`` values that produce a
+  decode batch bucket of exactly 4 (e.g. use 2 or 8 instead of 4).
+
+Usage examples
+--------------
+# Basic correctness check (PP=2, compare with PP=1 reference)
+python test_cpp.py --model meta-llama/Llama-3.2-1B --pp 2 --correctness
+
+# Performance benchmark
+python test_cpp.py --model meta-llama/Llama-3.2-1B --pp 2 --benchmark
+
+# Disable async send to measure its impact
+VLLM_RBLN_ASYNC_PP_SEND=0 python test_cpp.py --model meta-llama/Llama-3.2-1B --pp 2 --benchmark
+
+# Full test: correctness + benchmark
+python test_cpp.py --model meta-llama/Llama-3.2-1B --pp 2 --correctness --benchmark
+"""
+
+import argparse
+import os
+import time
+
+os.environ.setdefault("VLLM_RBLN_USE_VLLM_MODEL", "1")
+os.environ.setdefault("VLLM_USE_V1", "1")
+# Required: batch attention opt provides (B, 1) seq_idx to the compiler
+# instead of (B, num_partition) dyn_size_for_partitions which fails compilation.
+os.environ.setdefault("VLLM_RBLN_BATCH_ATTN_OPT", "1")
+
+from transformers import AutoTokenizer
+from vllm import LLM, SamplingParams
+
+
+def parse_args():
+    p = argparse.ArgumentParser(
+        description="CPP (Chunked Pipeline Parallelism) test & benchmark")
+    p.add_argument("--model", type=str, default="meta-llama/Llama-3.2-1B")
+    p.add_argument("--pp", type=int, default=2, help="pipeline_parallel_size")
+    p.add_argument("--tp", type=int, default=1, help="tensor_parallel_size")
+    p.add_argument("--max-model-len", type=int, default=2048)
+    p.add_argument(
+        "--max-num-seqs",
+        type=int,
+        default=2,
+        help="Avoid 4 (compiler bug at batch_bucket=4)",
+    )
+    p.add_argument(
+        "--max-num-batched-tokens",
+        type=int,
+        default=512,
+        help="Chunk size for chunked prefill",
+    )
+    p.add_argument("--block-size", type=int, default=1024)
+
+    # Test modes
+    p.add_argument(
+        "--correctness",
+        action="store_true",
+        help="Run correctness test (PP=1 vs PP=N)",
+    )
+    p.add_argument("--benchmark",
+                   action="store_true",
+                   help="Run performance benchmark")
+
+    # Benchmark parameters
+    p.add_argument("--num-requests", type=int, default=32)
+    p.add_argument("--input-len", type=int, default=1024)
+    p.add_argument("--output-len", type=int, default=128)
+    p.add_argument("--warmup-requests", type=int, default=3)
+    return p.parse_args()
+
+
+def build_llm(args, pp_override=None):
+    """Create an LLM instance with the given PP override."""
+    pp = pp_override if pp_override is not None else args.pp
+    return LLM(
+        model=args.model,
+        max_model_len=args.max_model_len,
+        max_num_seqs=args.max_num_seqs,
+        max_num_batched_tokens=args.max_num_batched_tokens,
+        block_size=args.block_size,
+        tensor_parallel_size=args.tp,
+        pipeline_parallel_size=pp,
+        enable_chunked_prefill=True,
+        enable_prefix_caching=False,
+        gpu_memory_utilization=1.0,
+        trust_remote_code=True,
+    )
+
+
+def make_prompts(tokenizer, num_requests, input_len):
+    """Build deterministic prompts with exactly *input_len* tokens each."""
+    # Use token IDs directly to guarantee exact length
+    dummy_ids = [1] * input_len  # token ID 1 repeated
+    prompt_text = tokenizer.decode(dummy_ids, skip_special_tokens=True)
+    # Verify and adjust
+    encoded = tokenizer.encode(prompt_text, add_special_tokens=True)
+    if len(encoded) != input_len:
+        # Fallback: repeat a single-char token
+        vocab = iter(tokenizer.vocab)
+        single_tok = next(vocab)
+        while True:
+            if len(tokenizer.encode(single_tok * 2,
+                                    add_special_tokens=False)) == 2:
+                break
+            single_tok = next(vocab)
+        prompt_text = single_tok * (input_len - 1)
+    return [prompt_text] * num_requests
+
+
+# -----------------------------------------------------------------------
+# Correctness test
+# -----------------------------------------------------------------------
+def run_correctness_test(args):
+    """Generate with PP=1 and PP=N, compare token-by-token."""
+    sampling = SamplingParams(temperature=0.0, max_tokens=args.output_len)
+
+    prompts = [
+        "The capital of France is",
+        "The president of the United States is",
+        "Once upon a time in a faraway land,",
+    ]
+
+    print("=" * 60)
+    print(f"Correctness test: PP=1 vs PP={args.pp}")
+    print("=" * 60)
+
+    # ---- PP=1 reference ----
+    print("\n[1/2] Running PP=1 reference ...")
+    llm_ref = build_llm(args, pp_override=1)
+    ref_outputs = llm_ref.generate(prompts, sampling)
+    ref_texts = [o.outputs[0].text for o in ref_outputs]
+    del llm_ref  # free resources
+
+    # ---- PP=N ----
+    print(f"\n[2/2] Running PP={args.pp} ...")
+    llm_pp = build_llm(args)
+    pp_outputs = llm_pp.generate(prompts, sampling)
+    pp_texts = [o.outputs[0].text for o in pp_outputs]
+    del llm_pp
+
+    # ---- compare ----
+    all_match = True
+    for i, (ref, pp) in enumerate(zip(ref_texts, pp_texts)):
+        match = ref == pp
+        status = "✓ MATCH" if match else "✗ MISMATCH"
+        print(f"  Prompt {i}: {status}")
+        if not match:
+            all_match = False
+            print(f"    PP=1:  {ref[:120]}...")
+            print(f"    PP={args.pp}: {pp[:120]}...")
+
+    print()
+    if all_match:
+        print("CORRECTNESS: PASSED ✓")
+    else:
+        print("CORRECTNESS: FAILED ✗")
+    return all_match
+
+
+# -----------------------------------------------------------------------
+# Performance benchmark
+# -----------------------------------------------------------------------
+def run_benchmark(args):
+    """Measure TTFT and decode throughput with chunked-prefill + PP."""
+    print("=" * 60)
+    print(f"Benchmark: PP={args.pp}  chunk={args.max_num_batched_tokens}  "
+          f"requests={args.num_requests}  in={args.input_len}  "
+          f"out={args.output_len}")
+    print(
+        f"  async_pp_send = {os.environ.get('VLLM_RBLN_ASYNC_PP_SEND', '1')}")
+    print("=" * 60)
+
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+    prompts = make_prompts(tokenizer, args.num_requests, args.input_len)
+
+    sampling = SamplingParams(
+        temperature=0.0,
+        ignore_eos=True,
+        max_tokens=args.output_len,
+    )
+
+    llm = build_llm(args)
+
+    # Warmup
+    print(f"\nWarmup ({args.warmup_requests} requests) ...")
+    _ = llm.generate(prompts[:min(len(prompts), args.warmup_requests)],
+                     sampling)
+
+    # Timed run
+    print("Timed run ...")
+    t0 = time.perf_counter()
+    outputs = llm.generate(prompts, sampling)
+    elapsed = time.perf_counter() - t0
+
+    # Validate output shapes
+    input_lens = [
+        len(o.prompt_token_ids) if o.prompt_token_ids else 0 for o in outputs
+    ]
+    output_lens = [len(o.outputs[0].token_ids) for o in outputs]
+    if any(l != args.input_len for l in input_lens):
+        print(f"  WARNING: Input length mismatch. Expected {args.input_len}, "
+              f"got {set(input_lens)}")
+    if any(l != args.output_len for l in output_lens):
+        print(
+            f"  WARNING: Output length mismatch. Expected {args.output_len}, "
+            f"got {set(output_lens)}")
+
+    total_input_tokens = args.num_requests * args.input_len
+    total_output_tokens = args.num_requests * args.output_len
+
+    print(f"\nResults:")
+    print(f"  Total time:           {elapsed:.2f} s")
+    print(f"  Prefill throughput:   {total_input_tokens / elapsed:.0f} tok/s")
+    print(f"  Decode throughput:    {total_output_tokens / elapsed:.0f} tok/s")
+    print(f"  Total throughput:     "
+          f"{(total_input_tokens + total_output_tokens) / elapsed:.0f} tok/s")
+    print(f"  Requests/sec:         {args.num_requests / elapsed:.2f}")
+
+    del llm
+    return elapsed
+
+
+def main():
+    args = parse_args()
+
+    if not args.correctness and not args.benchmark:
+        print("Specify --correctness and/or --benchmark. "
+              "Running both by default.\n")
+        args.correctness = True
+        args.benchmark = True
+
+    ok = True
+    if args.correctness:
+        ok = run_correctness_test(args)
+
+    if args.benchmark:
+        run_benchmark(args)
+
+    if not ok:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/experimental/test_cpp.py
+++ b/examples/experimental/test_cpp.py
@@ -51,17 +51,9 @@ python test_cpp.py --model meta-llama/Llama-3.2-1B --pp 2 --correctness --benchm
 """
 
 import argparse
+import gc
 import os
 import time
-
-os.environ.setdefault("VLLM_RBLN_USE_VLLM_MODEL", "1")
-os.environ.setdefault("VLLM_USE_V1", "1")
-# Required: batch attention opt provides (B, 1) seq_idx to the compiler
-# instead of (B, num_partition) dyn_size_for_partitions which fails compilation.
-os.environ.setdefault("VLLM_RBLN_BATCH_ATTN_OPT", "1")
-
-from transformers import AutoTokenizer
-from vllm import LLM, SamplingParams
 
 
 def parse_args():
@@ -105,6 +97,8 @@ def parse_args():
 
 def build_llm(args, pp_override=None):
     """Create an LLM instance with the given PP override."""
+    from vllm import LLM
+
     pp = pp_override if pp_override is not None else args.pp
     return LLM(
         model=args.model,
@@ -121,24 +115,15 @@ def build_llm(args, pp_override=None):
     )
 
 
-def make_prompts(tokenizer, num_requests, input_len):
-    """Build deterministic prompts with exactly *input_len* tokens each."""
-    # Use token IDs directly to guarantee exact length
-    dummy_ids = [1] * input_len  # token ID 1 repeated
-    prompt_text = tokenizer.decode(dummy_ids, skip_special_tokens=True)
-    # Verify and adjust
-    encoded = tokenizer.encode(prompt_text, add_special_tokens=True)
-    if len(encoded) != input_len:
-        # Fallback: repeat a single-char token
-        vocab = iter(tokenizer.vocab)
-        single_tok = next(vocab)
-        while True:
-            if len(tokenizer.encode(single_tok * 2,
-                                    add_special_tokens=False)) == 2:
-                break
-            single_tok = next(vocab)
-        prompt_text = single_tok * (input_len - 1)
-    return [prompt_text] * num_requests
+def make_prompts(num_requests, input_len):
+    """Build deterministic prompts with exactly *input_len* tokens each.
+
+    Returns token-ID lists (prompt_token_ids) to guarantee exact length,
+    avoiding encode/decode round-trip mismatches.
+    """
+    # Token ID 1 is a safe dummy in most tokenizers.
+    prompt_ids = [1] * input_len
+    return [prompt_ids] * num_requests
 
 
 # -----------------------------------------------------------------------
@@ -146,6 +131,8 @@ def make_prompts(tokenizer, num_requests, input_len):
 # -----------------------------------------------------------------------
 def run_correctness_test(args):
     """Generate with PP=1 and PP=N, compare token-by-token."""
+    from vllm import SamplingParams
+
     sampling = SamplingParams(temperature=0.0, max_tokens=args.output_len)
 
     prompts = [
@@ -163,7 +150,8 @@ def run_correctness_test(args):
     llm_ref = build_llm(args, pp_override=1)
     ref_outputs = llm_ref.generate(prompts, sampling)
     ref_texts = [o.outputs[0].text for o in ref_outputs]
-    del llm_ref  # free resources
+    del llm_ref
+    gc.collect()  # release NPU memory
 
     # ---- PP=N ----
     print(f"\n[2/2] Running PP={args.pp} ...")
@@ -171,6 +159,7 @@ def run_correctness_test(args):
     pp_outputs = llm_pp.generate(prompts, sampling)
     pp_texts = [o.outputs[0].text for o in pp_outputs]
     del llm_pp
+    gc.collect()
 
     # ---- compare ----
     all_match = True
@@ -196,6 +185,8 @@ def run_correctness_test(args):
 # -----------------------------------------------------------------------
 def run_benchmark(args):
     """Measure TTFT and decode throughput with chunked-prefill + PP."""
+    from vllm import SamplingParams
+
     print("=" * 60)
     print(f"Benchmark: PP={args.pp}  chunk={args.max_num_batched_tokens}  "
           f"requests={args.num_requests}  in={args.input_len}  "
@@ -204,8 +195,7 @@ def run_benchmark(args):
         f"  async_pp_send = {os.environ.get('VLLM_RBLN_ASYNC_PP_SEND', '1')}")
     print("=" * 60)
 
-    tokenizer = AutoTokenizer.from_pretrained(args.model)
-    prompts = make_prompts(tokenizer, args.num_requests, args.input_len)
+    prompt_ids = make_prompts(args.num_requests, args.input_len)
 
     sampling = SamplingParams(
         temperature=0.0,
@@ -217,13 +207,17 @@ def run_benchmark(args):
 
     # Warmup
     print(f"\nWarmup ({args.warmup_requests} requests) ...")
-    _ = llm.generate(prompts[:min(len(prompts), args.warmup_requests)],
-                     sampling)
+    _ = llm.generate(
+        prompt_token_ids=prompt_ids[:min(len(prompt_ids), args.warmup_requests
+                                         )],
+        sampling_params=sampling,
+    )
 
     # Timed run
     print("Timed run ...")
     t0 = time.perf_counter()
-    outputs = llm.generate(prompts, sampling)
+    outputs = llm.generate(prompt_token_ids=prompt_ids,
+                           sampling_params=sampling)
     elapsed = time.perf_counter() - t0
 
     # Validate output shapes
@@ -251,10 +245,18 @@ def run_benchmark(args):
     print(f"  Requests/sec:         {args.num_requests / elapsed:.2f}")
 
     del llm
+    gc.collect()
     return elapsed
 
 
 def main():
+    # Environment must be set before vLLM imports trigger module-level init.
+    os.environ.setdefault("VLLM_RBLN_USE_VLLM_MODEL", "1")
+    os.environ.setdefault("VLLM_USE_V1", "1")
+    # Required: batch attention opt provides (B, 1) seq_idx to the compiler
+    # instead of (B, num_partition) dyn_size_for_partitions which fails.
+    os.environ.setdefault("VLLM_RBLN_BATCH_ATTN_OPT", "1")
+
     args = parse_args()
 
     if not args.correctness and not args.benchmark:

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -152,8 +152,8 @@ environment_variables = {
     "VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT":
     lambda: int(os.environ.get("VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT", 1)),
     # Enable async P2P send for chunked pipeline parallelism (CPP).
-    # When True, non-last PP ranks send intermediate tensors in a
-    # background thread, allowing immediate computation of the next batch.
+    # When True, non-last PP ranks send intermediate tensors via
+    # non-blocking isend, allowing immediate computation of the next batch.
     "VLLM_RBLN_ASYNC_PP_SEND":
     (lambda: os.environ.get("VLLM_RBLN_ASYNC_PP_SEND", "True").lower() in
      ("true", "1")),

--- a/vllm_rbln/rbln_envs.py
+++ b/vllm_rbln/rbln_envs.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     VLLM_RBLN_DECODE_BATCH_BUCKET_MIN: int = 1
     VLLM_RBLN_DECODE_BATCH_BUCKET_STEP: int = 2
     VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT: int = 4
+    VLLM_RBLN_ASYNC_PP_SEND: bool = True
 
 
 def get_dp_impl():
@@ -150,6 +151,12 @@ environment_variables = {
     # Decode batch bucket limit
     "VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT":
     lambda: int(os.environ.get("VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT", 1)),
+    # Enable async P2P send for chunked pipeline parallelism (CPP).
+    # When True, non-last PP ranks send intermediate tensors in a
+    # background thread, allowing immediate computation of the next batch.
+    "VLLM_RBLN_ASYNC_PP_SEND":
+    (lambda: os.environ.get("VLLM_RBLN_ASYNC_PP_SEND", "True").lower() in
+     ("true", "1")),
 }
 
 

--- a/vllm_rbln/v1/worker/async_pp_communicator.py
+++ b/vllm_rbln/v1/worker/async_pp_communicator.py
@@ -47,6 +47,7 @@ from typing import Any
 
 import torch
 import torch.distributed
+from vllm.distributed.parallel_state import _split_tensor_dict
 
 from vllm_rbln.logger import init_logger
 
@@ -95,14 +96,11 @@ class AsyncPPCommunicator:
         # Determine destination (next rank in PP ring).
         dst_local = (pg.rank_in_group + 1) % pg.world_size
         dst_global = pg.ranks[dst_local]
-        metadata_group = pg.cpu_group
+        cpu_group = pg.cpu_group
 
         # --- Step 1: metadata (blocking) ---
         # Reuse vLLM's existing protocol: send_object sends
         # (size_tensor, object_tensor) via two blocking sends.
-        # _split_tensor_dict is a module-level helper in parallel_state.
-        from vllm.distributed.parallel_state import _split_tensor_dict
-
         metadata_list, tensor_list = _split_tensor_dict(tensor_dict)
         pg.send_object(metadata_list, dst=dst_local)
 
@@ -114,7 +112,7 @@ class AsyncPPCommunicator:
             work = torch.distributed.isend(
                 tensor,
                 dst=dst_global,
-                group=metadata_group,
+                group=cpu_group,
             )
             works.append(work)
 
@@ -124,11 +122,15 @@ class AsyncPPCommunicator:
         """Block until all in-flight ``isend`` operations complete.
 
         Must be called before reusing the tensor buffers that were passed
-        to ``async_send_tensor_dict``.
+        to ``async_send_tensor_dict``.  Safe to call when no sends are
+        pending (no-op).
         """
-        for work in self._pending_works:
+        # Swap out the list first so that a failing wait() does not leave
+        # stale Work objects that would be re-waited on the next call.
+        works = self._pending_works
+        self._pending_works = []
+        for work in works:
             work.wait()
-        self._pending_works.clear()
 
     def shutdown(self) -> None:
         """Best-effort cleanup — wait for any outstanding sends."""

--- a/vllm_rbln/v1/worker/async_pp_communicator.py
+++ b/vllm_rbln/v1/worker/async_pp_communicator.py
@@ -1,0 +1,117 @@
+# Copyright 2025 Rebellions Inc. All rights reserved.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at:
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Async P2P communicator for Chunked Pipeline Parallelism (CPP).
+
+When pipeline parallelism is enabled, each pipeline stage processes batches
+sequentially.  Without overlap, Stage 0 must wait for Stage 1 to receive
+its output before starting the next batch — creating a pipeline bubble.
+
+This module wraps the blocking ``send_tensor_dict`` call in a background
+thread so that the sending stage can immediately begin computing the next
+batch.  The engine core's ``step_with_batch_queue`` keeps multiple
+``SchedulerOutput`` objects in flight (up to ``pp_size``), which fills the
+pipeline and hides latency.
+
+Correctness guarantee
+---------------------
+``wait_pending_send()`` **must** be called before the model runner
+re-enters ``execute_model``, because the pre-allocated intermediate-tensor
+buffers are reused across batches.  The current call-site places the wait
+at the top of ``RBLNWorker.execute_model``, satisfying this invariant.
+"""
+
+import threading
+from typing import Any, Optional
+
+from vllm_rbln.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class AsyncPPCommunicator:
+    """Thread-based async sender for pipeline-parallel P2P communication.
+
+    One in-flight send is allowed at a time.  The caller is responsible for
+    invoking ``wait_pending_send`` before the underlying tensor buffers are
+    overwritten (see module docstring).
+    """
+
+    def __init__(self, pp_group) -> None:
+        self._pp_group = pp_group
+        self._send_thread: Optional[threading.Thread] = None
+        self._send_error: Optional[BaseException] = None
+        self._error_lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def async_send_tensor_dict(
+        self,
+        tensor_dict: dict[str, Any],
+    ) -> None:
+        """Start a non-blocking send of *tensor_dict* to the next PP stage.
+
+        The actual ``send_tensor_dict`` runs in a daemon thread.  The
+        caller **must not** mutate *tensor_dict* (or the tensors it
+        references) until the next ``wait_pending_send`` returns.
+        """
+        # Defensive: should already have been called by the worker, but
+        # guard against misuse.
+        self.wait_pending_send()
+
+        self._send_error = None
+        self._send_thread = threading.Thread(
+            target=self._do_send,
+            args=(tensor_dict, ),
+            daemon=True,
+        )
+        self._send_thread.start()
+
+    def wait_pending_send(self) -> None:
+        """Block until the in-flight send completes (if any).
+
+        Re-raises any exception captured by the background thread.
+        """
+        if self._send_thread is None:
+            return
+
+        self._send_thread.join()
+        self._send_thread = None
+
+        with self._error_lock:
+            if self._send_error is not None:
+                err = self._send_error
+                self._send_error = None
+                raise RuntimeError("Async PP send failed") from err
+
+    def shutdown(self) -> None:
+        """Best-effort cleanup — wait for the last send."""
+        try:
+            self.wait_pending_send()
+        except Exception:
+            logger.warning("Error during AsyncPPCommunicator shutdown",
+                           exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _do_send(self, tensor_dict: dict[str, Any]) -> None:
+        try:
+            self._pp_group.send_tensor_dict(tensor_dict)
+        except BaseException as exc:
+            with self._error_lock:
+                self._send_error = exc
+            logger.error("Async PP send raised: %s", exc)

--- a/vllm_rbln/v1/worker/async_pp_communicator.py
+++ b/vllm_rbln/v1/worker/async_pp_communicator.py
@@ -17,11 +17,23 @@ When pipeline parallelism is enabled, each pipeline stage processes batches
 sequentially.  Without overlap, Stage 0 must wait for Stage 1 to receive
 its output before starting the next batch — creating a pipeline bubble.
 
-This module wraps the blocking ``send_tensor_dict`` call in a background
-thread so that the sending stage can immediately begin computing the next
-batch.  The engine core's ``step_with_batch_queue`` keeps multiple
-``SchedulerOutput`` objects in flight (up to ``pp_size``), which fills the
-pipeline and hides latency.
+This module uses ``torch.distributed.isend`` (non-blocking send) so that
+the sending stage can immediately begin computing the next batch.  The
+engine core's ``step_with_batch_queue`` keeps multiple ``SchedulerOutput``
+objects in flight (up to ``pp_size``), which fills the pipeline and hides
+communication latency.
+
+Protocol
+--------
+``send_tensor_dict`` in vLLM's ``GroupCoordinator`` sends:
+
+1. **Metadata** (blocking) — pickle-serialized list of ``(key, value)``
+   pairs where tensor values are replaced by ``TensorMetadata``.
+   Two blocking sends: size tensor, then serialized object.
+2. **Tensor data** — one ``send()`` per tensor in dict order.
+
+We keep step 1 blocking (receiver needs metadata to allocate buffers)
+and replace step 2 with ``isend()`` for non-blocking tensor transfer.
 
 Correctness guarantee
 ---------------------
@@ -31,8 +43,10 @@ buffers are reused across batches.  The current call-site places the wait
 at the top of ``RBLNWorker.execute_model``, satisfying this invariant.
 """
 
-import threading
-from typing import Any, Optional
+from typing import Any
+
+import torch
+import torch.distributed
 
 from vllm_rbln.logger import init_logger
 
@@ -40,18 +54,20 @@ logger = init_logger(__name__)
 
 
 class AsyncPPCommunicator:
-    """Thread-based async sender for pipeline-parallel P2P communication.
+    """Non-blocking sender for pipeline-parallel P2P communication.
 
-    One in-flight send is allowed at a time.  The caller is responsible for
-    invoking ``wait_pending_send`` before the underlying tensor buffers are
-    overwritten (see module docstring).
+    Uses ``torch.distributed.isend`` for tensor data to overlap
+    communication with computation.  Metadata is still sent blocking
+    because the receiver needs it to allocate tensor buffers.
+
+    One set of in-flight sends is allowed at a time.  The caller is
+    responsible for invoking ``wait_pending_send`` before the underlying
+    tensor buffers are overwritten (see module docstring).
     """
 
     def __init__(self, pp_group) -> None:
         self._pp_group = pp_group
-        self._send_thread: Optional[threading.Thread] = None
-        self._send_error: Optional[BaseException] = None
-        self._error_lock = threading.Lock()
+        self._pending_works: list[torch.distributed.Work] = []
 
     # ------------------------------------------------------------------
     # Public API
@@ -61,57 +77,63 @@ class AsyncPPCommunicator:
         self,
         tensor_dict: dict[str, Any],
     ) -> None:
-        """Start a non-blocking send of *tensor_dict* to the next PP stage.
+        """Send *tensor_dict* to the next PP stage with non-blocking
+        tensor transfer.
 
-        The actual ``send_tensor_dict`` runs in a daemon thread.  The
-        caller **must not** mutate *tensor_dict* (or the tensors it
+        Metadata is sent synchronously (receiver needs it to allocate
+        buffers).  Tensor payloads use ``isend`` and can be waited on
+        later via ``wait_pending_send``.
+
+        The caller **must not** mutate *tensor_dict* (or the tensors it
         references) until the next ``wait_pending_send`` returns.
         """
-        # Defensive: should already have been called by the worker, but
-        # guard against misuse.
+        # Ensure previous sends completed before starting new ones.
         self.wait_pending_send()
 
-        self._send_error = None
-        self._send_thread = threading.Thread(
-            target=self._do_send,
-            args=(tensor_dict, ),
-            daemon=True,
-        )
-        self._send_thread.start()
+        pg = self._pp_group
+
+        # Determine destination (next rank in PP ring).
+        dst_local = (pg.rank_in_group + 1) % pg.world_size
+        dst_global = pg.ranks[dst_local]
+        metadata_group = pg.cpu_group
+
+        # --- Step 1: metadata (blocking) ---
+        # Reuse vLLM's existing protocol: send_object sends
+        # (size_tensor, object_tensor) via two blocking sends.
+        # _split_tensor_dict is a module-level helper in parallel_state.
+        from vllm.distributed.parallel_state import _split_tensor_dict
+
+        metadata_list, tensor_list = _split_tensor_dict(tensor_dict)
+        pg.send_object(metadata_list, dst=dst_local)
+
+        # --- Step 2: tensor data (non-blocking via isend) ---
+        works: list[torch.distributed.Work] = []
+        for tensor in tensor_list:
+            if tensor.numel() == 0:
+                continue
+            work = torch.distributed.isend(
+                tensor,
+                dst=dst_global,
+                group=metadata_group,
+            )
+            works.append(work)
+
+        self._pending_works = works
 
     def wait_pending_send(self) -> None:
-        """Block until the in-flight send completes (if any).
+        """Block until all in-flight ``isend`` operations complete.
 
-        Re-raises any exception captured by the background thread.
+        Must be called before reusing the tensor buffers that were passed
+        to ``async_send_tensor_dict``.
         """
-        if self._send_thread is None:
-            return
-
-        self._send_thread.join()
-        self._send_thread = None
-
-        with self._error_lock:
-            if self._send_error is not None:
-                err = self._send_error
-                self._send_error = None
-                raise RuntimeError("Async PP send failed") from err
+        for work in self._pending_works:
+            work.wait()
+        self._pending_works.clear()
 
     def shutdown(self) -> None:
-        """Best-effort cleanup — wait for the last send."""
+        """Best-effort cleanup — wait for any outstanding sends."""
         try:
             self.wait_pending_send()
         except Exception:
             logger.warning("Error during AsyncPPCommunicator shutdown",
                            exc_info=True)
-
-    # ------------------------------------------------------------------
-    # Internal
-    # ------------------------------------------------------------------
-
-    def _do_send(self, tensor_dict: dict[str, Any]) -> None:
-        try:
-            self._pp_group.send_tensor_dict(tensor_dict)
-        except BaseException as exc:
-            with self._error_lock:
-                self._send_error = exc
-            logger.error("Async PP send raised: %s", exc)

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -571,7 +571,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         src_indices = orig_indices[sorted_order]
         src_dest_map = {
             int(src): int(dst)
-            for src, dst in zip(src_indices, orig_indices)
+            for src, dst in zip(src_indices, orig_indices, strict=False)
         }
 
         for src in src_dest_map:
@@ -2476,7 +2476,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             # Broadcast PP output for external_launcher (torchrun)
             # to make sure we are synced across pp ranks
-            # TODO: Support overlapping mirco-batches
+            # NOTE: Overlapping micro-batches (CPP) is handled in
+            # RBLNWorker via AsyncPPCommunicator for the mp backend.
             # https://github.com/vllm-project/vllm/issues/18019
             broadcast_pp_output = \
                 self.parallel_config.distributed_executor_backend \

--- a/vllm_rbln/v1/worker/rbln_model_runner.py
+++ b/vllm_rbln/v1/worker/rbln_model_runner.py
@@ -27,22 +27,33 @@ import numpy as np
 import rebel
 import torch
 import torch.nn as nn
-from vllm.attention.backends.abstract import (AttentionBackend, AttentionType,
-                                              MultipleOf)
+from vllm.attention.backends.abstract import (
+    AttentionBackend,
+    AttentionType,
+    MultipleOf,
+)
 from vllm.attention.layer import Attention
 from vllm.config import VllmConfig, get_layers_from_vllm_config
 from vllm.distributed.eplb.eplb_state import EplbState
-from vllm.distributed.kv_transfer import (get_kv_transfer_group,
-                                          has_kv_transfer_group)
+from vllm.distributed.kv_transfer import (
+    get_kv_transfer_group,
+    has_kv_transfer_group,
+)
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
-from vllm.distributed.parallel_state import (get_dp_group, get_pp_group,
-                                             get_tp_group)
+from vllm.distributed.parallel_state import (
+    get_dp_group,
+    get_pp_group,
+    get_tp_group,
+)
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
 from vllm.model_executor.model_loader import TensorizerLoader, get_model_loader
 from vllm.model_executor.models.interfaces import supports_transcription
 from vllm.model_executor.models.interfaces_base import (
-    VllmModelForPooling, is_pooling_model, is_text_generation_model)
+    VllmModelForPooling,
+    is_pooling_model,
+    is_text_generation_model,
+)
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams, SamplingType
@@ -53,9 +64,15 @@ from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.utils.torch_utils import get_dtype_size, kv_cache_dtype_str_to_dtype
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadataBuilder
 from vllm.v1.attention.backends.utils import (
-    CommonAttentionMetadata, create_fast_prefill_custom_backend)
-from vllm.v1.core.sched.output import (CachedRequestData, NewRequestData,
-                                       SchedulerOutput)
+    CommonAttentionMetadata,
+    create_fast_prefill_custom_backend,
+)
+from vllm.v1.core.sched.output import (
+    CachedRequestData,
+    NewRequestData,
+    SchedulerOutput,
+)
+
 # yapf conflicts with isort for this block
 # yapf: disable
 from vllm.v1.kv_cache_interface import (AttentionSpec, CrossAttentionSpec,
@@ -64,9 +81,16 @@ from vllm.v1.kv_cache_interface import (AttentionSpec, CrossAttentionSpec,
                                         KVCacheSpec, MambaSpec,
                                         UniformTypeKVCacheSpecs)
 # yapf: enable
-from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput,
-                             DraftTokenIds, KVConnectorOutput, LogprobsLists,
-                             LogprobsTensors, ModelRunnerOutput, SamplerOutput)
+from vllm.v1.outputs import (
+    EMPTY_MODEL_RUNNER_OUTPUT,
+    AsyncModelRunnerOutput,
+    DraftTokenIds,
+    KVConnectorOutput,
+    LogprobsLists,
+    LogprobsTensors,
+    ModelRunnerOutput,
+    SamplerOutput,
+)
 from vllm.v1.sample.logits_processor import build_logitsprocs
 from vllm.v1.sample.logits_processor.interface import LogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
@@ -81,11 +105,15 @@ from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.kv_connector_model_runner_mixin import (
-    KVConnectorModelRunnerMixin)
+    KVConnectorModelRunnerMixin,
+)
 from vllm.v1.worker.lora_model_runner_mixin import LoRAModelRunnerMixin
-from vllm.v1.worker.utils import (AttentionGroup, MultiModalBudget,
-                                  add_kv_sharing_layers_to_kv_cache_groups,
-                                  bind_kv_cache)
+from vllm.v1.worker.utils import (
+    AttentionGroup,
+    MultiModalBudget,
+    add_kv_sharing_layers_to_kv_cache_groups,
+    bind_kv_cache,
+)
 
 import vllm_rbln.rbln_envs as envs
 import vllm_rbln.utils as rbln_utils
@@ -94,7 +122,8 @@ from vllm_rbln.logger import init_logger
 from vllm_rbln.lora.inputs import LoRAInputs
 from vllm_rbln.lora.mask import LoRAMask
 from vllm_rbln.v1.attention.backends.flash_attention import (
-    RBLNFlashAttentionMetadataBuilder)
+    RBLNFlashAttentionMetadataBuilder,
+)
 from vllm_rbln.v1.kv_cache import RBLNSlidingWindowSpec
 from vllm_rbln.v1.sample import RBLNSampler
 from vllm_rbln.v1.worker.bucketing import get_bucketing_manager_class
@@ -109,7 +138,6 @@ logger = init_logger(__name__)
 
 # Wrapper for ModelRunnerOutput to support overlapped execution.
 class AsyncRBLNModelRunnerOutput(AsyncModelRunnerOutput):
-
     def __init__(
         self,
         model_runner_output: ModelRunnerOutput,
@@ -178,7 +206,6 @@ class DummyRunState(NamedTuple):
 
 
 class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
-
     def __init__(
         self,
         vllm_config: VllmConfig,
@@ -196,8 +223,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.observability_config = vllm_config.observability_config
 
         from vllm.model_executor.models.utils import set_cpu_offload_max_bytes
+
         set_cpu_offload_max_bytes(
-            int(self.cache_config.cpu_offload_gb * 1024**3))
+            int(self.cache_config.cpu_offload_gb * 1024**3)
+        )
         assert self.cache_config.cpu_offload_gb == 0, "Not support cpu offload"
 
         model_config = self.model_config
@@ -208,11 +237,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.pin_memory = is_pin_memory_available()
         self.dtype = self.model_config.dtype
         self.kv_cache_dtype = kv_cache_dtype_str_to_dtype(
-            cache_config.cache_dtype, self.model_config)
+            cache_config.cache_dtype, self.model_config
+        )
 
-        self.is_pooling_model = (model_config.runner_type == 'pooling')
+        self.is_pooling_model = model_config.runner_type == "pooling"
         self.is_multimodal_raw_input_only_model = (
-            model_config.is_multimodal_raw_input_only_model)
+            model_config.is_multimodal_raw_input_only_model
+        )
 
         self.max_model_len = model_config.max_model_len
         self.dcp_world_size = self.parallel_config.decode_context_parallel_size
@@ -221,7 +252,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Model-related.
         self.num_query_heads = model_config.get_num_attention_heads(
-            parallel_config)
+            parallel_config
+        )
         self.inputs_embeds_size = model_config.get_inputs_embeds_size()
         self.attention_chunk_size = model_config.attention_chunk_size
         # Only relevant for models using ALiBi (e.g, MPT)
@@ -236,7 +268,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         assert not self.uses_mrope, "RBLN does not support M-RoPE."
 
         self.supports_mm_inputs = self.mm_registry.supports_multimodal_inputs(
-            model_config)
+            model_config
+        )
         if envs.VLLM_RBLN_DISABLE_MM:
             self.supports_mm_inputs = False
 
@@ -287,31 +320,40 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # the last PP rank. This is not ideal if there are many
         # layers in the draft model.
         if self.speculative_config and get_pp_group().is_last_rank:
-            self.drafter: (NgramProposer | SuffixDecodingProposer
-                           | EagleProposer | MedusaProposer)
+            self.drafter: (
+                NgramProposer
+                | SuffixDecodingProposer
+                | EagleProposer
+                | MedusaProposer
+            )
             if self.speculative_config.method == "ngram":
                 self.drafter = NgramProposer(self.vllm_config)
             # elif self.speculative_config.method == "suffix":
             #     self.drafter = SuffixDecodingProposer(self.vllm_config)
             elif self.speculative_config.use_eagle():
-                self.drafter = EagleProposer(self.vllm_config, self.device,
-                                             self)  # type: ignore
+                self.drafter = EagleProposer(
+                    self.vllm_config, self.device, self
+                )  # type: ignore
                 if self.speculative_config.method == "eagle3":
-                    self.use_aux_hidden_state_outputs = \
+                    self.use_aux_hidden_state_outputs = (
                         self.drafter.eagle3_use_aux_hidden_state
+                    )
             elif self.speculative_config.method == "medusa":
                 self.drafter = MedusaProposer(
-                    vllm_config=self.vllm_config,
-                    device=self.device)  # type: ignore
+                    vllm_config=self.vllm_config, device=self.device
+                )  # type: ignore
             else:
-                raise ValueError("Unknown speculative decoding method: "
-                                 f"{self.speculative_config.method}")
+                raise ValueError(
+                    "Unknown speculative decoding method: "
+                    f"{self.speculative_config.method}"
+                )
             self.rejection_sampler = RejectionSampler(self.sampler)
 
         self.num_spec_tokens = 0
         if self.speculative_config:
-            self.num_spec_tokens = \
+            self.num_spec_tokens = (
                 self.speculative_config.num_speculative_tokens
+            )
 
         # Request states.
         self.requests: dict[str, CachedRequestState] = {}
@@ -330,7 +372,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # the block_sizes in the kv cache config.
         logits_processors = model_config.logits_processors
         custom_logitsprocs: Sequence[Union[str, type[LogitsProcessor]]] = (
-            tuple(logits_processors) if logits_processors is not None else ())
+            tuple(logits_processors) if logits_processors is not None else ()
+        )
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
             # We need to use the encoder length for encoder-decoer
@@ -354,8 +397,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # processor uses output token ids so we set this conservatively.
             logitsprocs_need_output_token_ids=bool(custom_logitsprocs),
             is_pooling_model=self.is_pooling_model,
-            cp_kv_cache_interleave_size=self.parallel_config.
-            cp_kv_cache_interleave_size,
+            cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
 
         self.use_async_scheduling = self.scheduler_config.async_scheduling
@@ -366,26 +408,34 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self._init_device_properties()
 
         # Persistent buffers for graphs.
-        self.input_ids = self._make_buffer(self.max_num_tokens,
-                                           dtype=torch.int32)
-        self.positions = self._make_buffer(self.max_num_tokens,
-                                           dtype=torch.int64)
-        self.query_start_loc = self._make_buffer(self.max_num_reqs + 1,
-                                                 dtype=torch.int32)
+        self.input_ids = self._make_buffer(
+            self.max_num_tokens, dtype=torch.int32
+        )
+        self.positions = self._make_buffer(
+            self.max_num_tokens, dtype=torch.int64
+        )
+        self.query_start_loc = self._make_buffer(
+            self.max_num_reqs + 1, dtype=torch.int32
+        )
         self.seq_lens = self._make_buffer(self.max_num_reqs, dtype=torch.int32)
         # Because inputs_embeds may be bfloat16 and we don't need a numpy
         # version of this tensor, avoid a RuntimeError by not creating a
         # numpy buffer.
-        self.inputs_embeds = self._make_buffer(self.max_num_tokens,
-                                               self.inputs_embeds_size,
-                                               dtype=self.dtype,
-                                               numpy=False)
-        self.discard_request_mask = self._make_buffer(self.max_num_reqs,
-                                                      dtype=torch.bool)
-        self.num_decode_draft_tokens = self._make_buffer(self.max_num_reqs,
-                                                         dtype=torch.int32)
-        self.num_accepted_tokens = self._make_buffer(self.max_num_reqs,
-                                                     dtype=torch.int64)
+        self.inputs_embeds = self._make_buffer(
+            self.max_num_tokens,
+            self.inputs_embeds_size,
+            dtype=self.dtype,
+            numpy=False,
+        )
+        self.discard_request_mask = self._make_buffer(
+            self.max_num_reqs, dtype=torch.bool
+        )
+        self.num_decode_draft_tokens = self._make_buffer(
+            self.max_num_reqs, dtype=torch.int32
+        )
+        self.num_accepted_tokens = self._make_buffer(
+            self.max_num_reqs, dtype=torch.int64
+        )
 
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
         if self.uses_mrope:
@@ -400,7 +450,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # 1D-RoPE.
             # See page 5 of https://arxiv.org/abs/2409.12191
             self.mrope_positions = self._make_buffer(
-                (3, self.max_num_tokens + 1), dtype=torch.int64)
+                (3, self.max_num_tokens + 1), dtype=torch.int64
+            )
 
         # None in the first PP rank. The rest are set after load_model.
         self.prefill_intermediate_tensors: Optional[IntermediateTensors] = None
@@ -408,10 +459,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # OPTIMIZATION: Cache the tensors rather than creating them every step.
         # Keep in int64 to avoid overflow with long context
-        self.arange_np = np.arange(max(self.max_num_reqs + 1,
-                                       self.max_model_len,
-                                       self.max_num_tokens),
-                                   dtype=np.int64)
+        self.arange_np = np.arange(
+            max(self.max_num_reqs + 1, self.max_model_len, self.max_num_tokens),
+            dtype=np.int64,
+        )
 
         # Layer pairings for cross-layer KV sharing.
         # If an Attention layer `layer_name` is in the keys of this dict, it
@@ -423,16 +474,24 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.kv_sharing_fast_prefill_logits_indices = None
         if self.cache_config.kv_sharing_fast_prefill:
             self.kv_sharing_fast_prefill_logits_indices = torch.zeros(
-                self.max_num_tokens, dtype=torch.int32, device=self.device)
+                self.max_num_tokens, dtype=torch.int32, device=self.device
+            )
 
-        self.uniform_decode_query_len = 1 if not self.speculative_config else \
-            1 + self.speculative_config.num_speculative_tokens
+        self.uniform_decode_query_len = (
+            1
+            if not self.speculative_config
+            else 1 + self.speculative_config.num_speculative_tokens
+        )
 
-        self.mm_budget = MultiModalBudget(
-            self.model_config,
-            self.scheduler_config,
-            self.mm_registry,
-        ) if self.supports_mm_inputs else None
+        self.mm_budget = (
+            MultiModalBudget(
+                self.model_config,
+                self.scheduler_config,
+                self.mm_registry,
+            )
+            if self.supports_mm_inputs
+            else None
+        )
 
         self.reorder_batch_threshold: Optional[int] = None
 
@@ -442,8 +501,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.runner_only_attn_layers: set[str] = set()
 
         # Cached outputs.
-        self._draft_token_ids: Optional[Union[list[list[int]],
-                                              torch.Tensor]] = None
+        self._draft_token_ids: Optional[
+            Union[list[list[int]], torch.Tensor]
+        ] = None
         self.sampled_token_ids_pinned_cpu = torch.empty(
             (self.max_model_len, 1),
             dtype=torch.int64,
@@ -457,32 +517,41 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # execute_model() and sample_tokens().
         self.execute_model_state: ExecuteModelState | None = None
 
-        self.max_batch_size = (self.scheduler_config.max_num_seqs //
-                               self.parallel_config.pipeline_parallel_size)
+        self.max_batch_size = (
+            self.scheduler_config.max_num_seqs
+            // self.parallel_config.pipeline_parallel_size
+        )
         self.max_num_seqs = self.scheduler_config.max_num_seqs
         self.max_prefill_batch_size = 1
         self.max_num_batched_tokens = (
-            self.scheduler_config.max_num_batched_tokens)
+            self.scheduler_config.max_num_batched_tokens
+        )
 
         bucketing_manager_class = get_bucketing_manager_class(
-            envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY)
+            envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STRATEGY
+        )
         self.bucketing_manager = bucketing_manager_class(
             max_batch_size=self.max_batch_size,
             min_batch_size=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_MIN,
             step=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_STEP,
             limit=envs.VLLM_RBLN_DECODE_BATCH_BUCKET_LIMIT,
         )
-        logger.info("Using %s bucketing manager",
-                    bucketing_manager_class.__name__)
-        logger.info("decode batch buckets: %s",
-                    self.bucketing_manager.decode_batch_buckets)
+        logger.info(
+            "Using %s bucketing manager", bucketing_manager_class.__name__
+        )
+        logger.info(
+            "decode batch buckets: %s",
+            self.bucketing_manager.decode_batch_buckets,
+        )
 
         self.performance_tracker = None
 
         self.dummy_run_state: DummyRunState | None = None
 
-        self.specialized_moe_decode = parallel_config.data_parallel_size > 1 \
+        self.specialized_moe_decode = (
+            parallel_config.data_parallel_size > 1
             and envs.VLLM_RBLN_SPECIALIZE_MOE_DECODE
+        )
 
     def _enable_performance_tracker(self):
         if envs.VLLM_RBLN_METRICS:
@@ -503,15 +572,19 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             #     return self.xdrope_positions.gpu[:, num_tokens]
             return self.positions.gpu[num_tokens]
 
-    def _make_buffer(self,
-                     *size: Union[int, torch.SymInt],
-                     dtype: torch.dtype,
-                     numpy: bool = True) -> CpuGpuBuffer:
-        return CpuGpuBuffer(*size,
-                            dtype=dtype,
-                            device=self.device,
-                            pin_memory=self.pin_memory,
-                            with_numpy=numpy)
+    def _make_buffer(
+        self,
+        *size: Union[int, torch.SymInt],
+        dtype: torch.dtype,
+        numpy: bool = True,
+    ) -> CpuGpuBuffer:
+        return CpuGpuBuffer(
+            *size,
+            dtype=dtype,
+            device=self.device,
+            pin_memory=self.pin_memory,
+            with_numpy=numpy,
+        )
 
     def _init_model_kwargs(self, num_tokens: int):
         model_kwargs = dict[str, Any]()
@@ -524,9 +597,15 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         token_type_id_requests = dict[int, Any]()
         for i, param in enumerate(pooling_params):
-            if param.extra_kwargs is not None and \
-            (token_types := param.extra_kwargs.get(
-                "compressed_token_type_ids")) is not None:
+            if (
+                param.extra_kwargs is not None
+                and (
+                    token_types := param.extra_kwargs.get(
+                        "compressed_token_type_ids"
+                    )
+                )
+                is not None
+            ):
                 token_type_id_requests[i] = token_types
 
         if len(token_type_id_requests) == 0:
@@ -541,7 +620,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             token_type_ids.append(ids)
 
         model_kwargs["token_type_ids"] = torch.concat(token_type_ids).to(
-            device=self.device)
+            device=self.device
+        )
         return model_kwargs
 
     def _may_reorder_batch(self, scheduler_output: SchedulerOutput) -> None:
@@ -565,9 +645,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             return
 
         orig_indices = np.arange(len(self.input_batch.req_ids))
-        sorted_order = np.argsort(self.input_batch.num_tokens[orig_indices] *
-                                  (-1),
-                                  kind="stable")
+        sorted_order = np.argsort(
+            self.input_batch.num_tokens[orig_indices] * (-1), kind="stable"
+        )
         src_indices = orig_indices[sorted_order]
         src_dest_map = {
             int(src): int(dst)
@@ -640,8 +720,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             sampling_params = new_req_data.sampling_params
             pooling_params = new_req_data.pooling_params
 
-            if sampling_params and \
-                sampling_params.sampling_type == SamplingType.RANDOM_SEED:
+            if (
+                sampling_params
+                and sampling_params.sampling_type == SamplingType.RANDOM_SEED
+            ):
                 generator = torch.Generator(device=self.device)
                 generator.manual_seed(sampling_params.seed)
             else:
@@ -673,8 +755,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if sampling_params and sampling_params.prompt_logprobs is not None:
                 self.num_prompt_logprobs[req_id] = (
                     self.input_batch.vocab_size
-                    if sampling_params.prompt_logprobs == -1 else
-                    sampling_params.prompt_logprobs)
+                    if sampling_params.prompt_logprobs == -1
+                    else sampling_params.prompt_logprobs
+                )
 
             # TODO(jiwoo.park) We don't support M-RoPE yet.
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -702,22 +785,26 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 new_token_ids = req_data.new_token_ids[i]
                 # Add the sampled token(s) from the previous step (if any).
                 # This doesn't include "unverified" tokens like spec tokens.
-                num_new_tokens = (num_computed_tokens + len(new_token_ids) -
-                                  req_state.num_tokens)
+                num_new_tokens = (
+                    num_computed_tokens
+                    + len(new_token_ids)
+                    - req_state.num_tokens
+                )
                 if num_new_tokens == 1:
                     # Avoid slicing list in most common case.
                     req_state.output_token_ids.append(new_token_ids[-1])
                 elif num_new_tokens > 0:
                     req_state.output_token_ids.extend(
-                        new_token_ids[-num_new_tokens:])
+                        new_token_ids[-num_new_tokens:]
+                    )
 
             # Update the block IDs.
             if not resumed_from_preemption:
                 if new_block_ids is not None:
                     # Append the new blocks to the existing block IDs.
-                    for block_ids, new_ids in zip(req_state.block_ids,
-                                                  new_block_ids,
-                                                  strict=False):
+                    for block_ids, new_ids in zip(
+                        req_state.block_ids, new_block_ids, strict=False
+                    ):
                         block_ids.extend(new_ids)
             else:
                 assert new_block_ids is not None
@@ -735,10 +822,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             # Update the persistent batch.
             self.input_batch.num_computed_tokens_cpu[req_index] = (
-                num_computed_tokens)
+                num_computed_tokens
+            )
             if new_block_ids is not None:
                 self.input_batch.block_table.append_row(
-                    new_block_ids, req_index)
+                    new_block_ids, req_index
+                )
 
             # For the last rank, we don't need to update the token_ids_cpu
             # because the sampled tokens are already cached.
@@ -747,21 +836,22 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 start_token_index = num_computed_tokens
                 end_token_index = num_computed_tokens + len(new_token_ids)
                 self.input_batch.token_ids_cpu[
-                    req_index,
-                    start_token_index:end_token_index] = new_token_ids
-                self.input_batch.num_tokens_no_spec[
-                    req_index] = end_token_index
+                    req_index, start_token_index:end_token_index
+                ] = new_token_ids
+                self.input_batch.num_tokens_no_spec[req_index] = end_token_index
                 self.input_batch.num_tokens[req_index] = end_token_index
 
             # Add spec_token_ids to token_ids_cpu.
-            spec_token_ids = (
-                scheduler_output.scheduled_spec_decode_tokens.get(req_id, ()))
+            spec_token_ids = scheduler_output.scheduled_spec_decode_tokens.get(
+                req_id, ()
+            )
             if spec_token_ids:
                 num_spec_tokens = len(spec_token_ids)
                 start_index = self.input_batch.num_tokens_no_spec[req_index]
                 end_token_index = start_index + num_spec_tokens
                 self.input_batch.token_ids_cpu[
-                    req_index, start_index:end_token_index] = spec_token_ids
+                    req_index, start_index:end_token_index
+                ] = spec_token_ids
                 # NOTE(woosuk): `num_tokens` here may include spec tokens.
                 self.input_batch.num_tokens[req_index] += num_spec_tokens
 
@@ -786,7 +876,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         self.input_batch.refresh_metadata()
 
     def _update_states_after_model_execute(
-            self, output_token_ids: torch.Tensor) -> None:
+        self, output_token_ids: torch.Tensor
+    ) -> None:
         """Update the cached states after model execution.
 
         This is used for MTP/EAGLE for hybrid models, as in linear attention,
@@ -799,14 +890,26 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             return
 
         # Find the number of accepted tokens for each sequence.
-        num_accepted_tokens = (torch.cat(
-            [
-                output_token_ids,
-                torch.full((output_token_ids.size(0), 1),
-                           -1,
-                           device=output_token_ids.device),
-            ],
-            dim=1) == -1).int().argmax(-1).cpu().numpy()
+        num_accepted_tokens = (
+            (
+                torch.cat(
+                    [
+                        output_token_ids,
+                        torch.full(
+                            (output_token_ids.size(0), 1),
+                            -1,
+                            device=output_token_ids.device,
+                        ),
+                    ],
+                    dim=1,
+                )
+                == -1
+            )
+            .int()
+            .argmax(-1)
+            .cpu()
+            .numpy()
+        )
         for i, num_tokens in enumerate(num_accepted_tokens):
             self.input_batch.num_accepted_tokens_cpu[i] = num_tokens
 
@@ -830,9 +933,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         return cu_num_tokens, arange
 
-    def _prepare_input_ids(self, scheduler_output: "SchedulerOutput",
-                           total_num_scheduled_tokens: int,
-                           cu_num_tokens: np.ndarray) -> None:
+    def _prepare_input_ids(
+        self,
+        scheduler_output: "SchedulerOutput",
+        total_num_scheduled_tokens: int,
+        cu_num_tokens: np.ndarray,
+    ) -> None:
         """Prepare the input IDs for the current batch.
 
         Carefully handles the `prev_sampled_token_ids` which can be cached
@@ -871,8 +977,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # spec_flattened_indices = [1,   3, 4,    6, 7]
                 sample_flattened_indices.append(flattened_index - draft_len)
                 spec_flattened_indices.extend(
-                    range(flattened_index - draft_len + 1,
-                          flattened_index + 1))
+                    range(flattened_index - draft_len + 1, flattened_index + 1)
+                )
                 start = prev_index * self.num_spec_tokens
                 # prev_draft_token_indices is used to find which draft_tokens_id
                 # should be copied to input_ids
@@ -880,8 +986,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # flatten draft_tokens_id [1,2,3,4,5,6]
                 # draft_len of each request [1, 2, 1]
                 # then prev_draft_token_indices is [0,   2, 3,   4]
-                prev_draft_token_indices.extend(range(start,
-                                                      start + draft_len))
+                prev_draft_token_indices.extend(range(start, start + draft_len))
                 indices_match &= prev_index == flattened_index
                 max_flattened_index = max(max_flattened_index, flattened_index)
         num_commmon_tokens = len(sample_flattened_indices)
@@ -903,8 +1008,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # The indices are both the same permutation of 0..N-1 so
             # we can copy directly using a single slice.
             self.input_ids.gpu[:num_commmon_tokens].copy_(
-                self.input_batch.prev_sampled_token_ids[:num_commmon_tokens,
-                                                        0],
+                self.input_batch.prev_sampled_token_ids[:num_commmon_tokens, 0],
                 non_blocking=True,
             )
             # if self.enable_prompt_embeds:
@@ -915,16 +1019,19 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         sampled_tokens_index_tensor = torch.tensor(
             sample_flattened_indices,
             dtype=torch.int64,
-            pin_memory=self.pin_memory).to(self.device, non_blocking=True)
+            pin_memory=self.pin_memory,
+        ).to(self.device, non_blocking=True)
         prev_common_req_indices_tensor = torch.tensor(
             prev_common_req_indices,
             dtype=torch.int64,
-            pin_memory=self.pin_memory).to(self.device, non_blocking=True)
+            pin_memory=self.pin_memory,
+        ).to(self.device, non_blocking=True)
         self.input_ids.gpu.scatter_(
             dim=0,
             index=sampled_tokens_index_tensor,
             src=self.input_batch.prev_sampled_token_ids[
-                prev_common_req_indices_tensor, 0],
+                prev_common_req_indices_tensor, 0
+            ],
         )
 
         # Scatter the draft tokens after the sampled tokens are scattered.
@@ -935,11 +1042,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         draft_tokens_index_tensor = torch.tensor(
             spec_flattened_indices,
             dtype=torch.int64,
-            pin_memory=self.pin_memory).to(self.device, non_blocking=True)
+            pin_memory=self.pin_memory,
+        ).to(self.device, non_blocking=True)
         prev_draft_token_indices_tensor = torch.tensor(
             prev_draft_token_indices,
             dtype=torch.int64,
-            pin_memory=self.pin_memory).to(self.device, non_blocking=True)
+            pin_memory=self.pin_memory,
+        ).to(self.device, non_blocking=True)
 
         # because input_ids dtype is torch.int32,
         # so convert draft_token_ids to torch.int32 here.
@@ -975,8 +1084,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         scheduler_output: SchedulerOutput,
         num_scheduled_tokens: np.ndarray,
         num_padded_tokens: int | None = None,
-    ) -> tuple[dict[str, Any], torch.Tensor, Optional[SpecDecodeMetadata],
-               np.ndarray, Optional[CommonAttentionMetadata], int]:
+    ) -> tuple[
+        dict[str, Any],
+        torch.Tensor,
+        Optional[SpecDecodeMetadata],
+        np.ndarray,
+        Optional[CommonAttentionMetadata],
+        int,
+    ]:
         """
         :return: tuple[
             attn_metadata: layer-to-attention_metadata mapping,
@@ -994,19 +1109,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Get request indices.
         # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
-        req_indices = np.repeat(self.arange_np[:num_reqs],
-                                num_scheduled_tokens)
+        req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
 
         # cu_num_tokens: [2, 5, 3] -> [2, 7, 10]
         # arange: [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         cu_num_tokens, arange = self._get_cumsum_and_arange(
-            num_scheduled_tokens)
+            num_scheduled_tokens
+        )
 
         # Get positions.
         positions_np = self.positions.np[:total_num_scheduled_tokens]
-        np.add(self.input_batch.num_computed_tokens_cpu[req_indices],
-               arange,
-               out=positions_np)
+        np.add(
+            self.input_batch.num_computed_tokens_cpu[req_indices],
+            arange,
+            out=positions_np,
+        )
 
         # Calculate M-RoPE positions.
         # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
@@ -1017,34 +1134,40 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        token_indices = (positions_np +
-                         req_indices * self.input_batch.token_ids_cpu.shape[1])
+        token_indices = (
+            positions_np + req_indices * self.input_batch.token_ids_cpu.shape[1]
+        )
 
         # NOTE(woosuk): We use torch.index_select instead of np.take here
         # because torch.index_select is much faster than np.take for large
         # tensors.
-        torch.index_select(self.input_batch.token_ids_cpu_tensor.flatten(),
-                           0,
-                           torch.from_numpy(token_indices),
-                           out=self.input_ids.cpu[:total_num_scheduled_tokens])
+        torch.index_select(
+            self.input_batch.token_ids_cpu_tensor.flatten(),
+            0,
+            torch.from_numpy(token_indices),
+            out=self.input_ids.cpu[:total_num_scheduled_tokens],
+        )
 
         self.input_batch.block_table.compute_slot_mapping(
-            req_indices, positions_np)
+            req_indices, positions_np
+        )
         self.input_batch.block_table.commit_slot_mapping(
-            total_num_scheduled_tokens)
+            total_num_scheduled_tokens
+        )
 
         # Prepare the attention metadata.
         self.query_start_loc.np[0] = 0
-        self.query_start_loc.np[1:num_reqs + 1] = cu_num_tokens
+        self.query_start_loc.np[1 : num_reqs + 1] = cu_num_tokens
         # Note: pad query_start_loc to be non-decreasing, as kernels
         # like FlashAttention requires that
-        self.query_start_loc.np[num_reqs + 1:].fill(cu_num_tokens[-1])
+        self.query_start_loc.np[num_reqs + 1 :].fill(cu_num_tokens[-1])
         self.query_start_loc.copy_to_gpu()
-        query_start_loc = self.query_start_loc.gpu[:num_reqs + 1]
+        query_start_loc = self.query_start_loc.gpu[: num_reqs + 1]
 
         self.seq_lens.np[:num_reqs] = (
-            self.input_batch.num_computed_tokens_cpu[:num_reqs] +
-            num_scheduled_tokens)
+            self.input_batch.num_computed_tokens_cpu[:num_reqs]
+            + num_scheduled_tokens
+        )
         # Fill unused with 0 for full cuda graph mode.
         self.seq_lens.np[num_reqs:].fill(0)
         self.seq_lens.copy_to_gpu()
@@ -1052,20 +1175,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Copy the tensors to the GPU.
         # TODO(jiwoo.park) Currently, this code is meaningless.(overhead)
         # The input_ids may be padded by chunk size and max batch size.
-        self._prepare_input_ids(scheduler_output, total_num_scheduled_tokens,
-                                cu_num_tokens)
+        self._prepare_input_ids(
+            scheduler_output, total_num_scheduled_tokens, cu_num_tokens
+        )
 
         if self.uses_mrope:
             # Only relevant for models using M-RoPE (e.g, Qwen2-VL)
             self.mrope_positions.gpu[:, :total_num_scheduled_tokens].copy_(
                 self.mrope_positions.cpu[:, :total_num_scheduled_tokens],
-                non_blocking=True)
+                non_blocking=True,
+            )
         else:
             # Common case (1D positions)
             self.positions.copy_to_gpu(total_num_scheduled_tokens)
 
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
+        use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
         if not use_spec_decode:
             # NOTE(woosuk): Due to chunked prefills, the batch may contain
             # partial requests. While we should not sample any token
@@ -1082,16 +1206,24 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # requests have draft tokens.
             num_draft_tokens = np.zeros(num_reqs, dtype=np.int32)
             num_decode_draft_tokens = np.full(num_reqs, -1, dtype=np.int32)
-            for req_id, draft_token_ids in (
-                    scheduler_output.scheduled_spec_decode_tokens.items()):
+            for (
+                req_id,
+                draft_token_ids,
+            ) in scheduler_output.scheduled_spec_decode_tokens.items():
                 req_idx = self.input_batch.req_id_to_index[req_id]
                 num_draft_tokens[req_idx] = len(draft_token_ids)
-                num_decode_draft_tokens[req_idx] = (len(draft_token_ids) if (
-                    self.input_batch.num_computed_tokens_cpu[req_idx]
-                    >= self.input_batch.num_prompt_tokens[req_idx]) else -1)
+                num_decode_draft_tokens[req_idx] = (
+                    len(draft_token_ids)
+                    if (
+                        self.input_batch.num_computed_tokens_cpu[req_idx]
+                        >= self.input_batch.num_prompt_tokens[req_idx]
+                    )
+                    else -1
+                )
 
             spec_decode_metadata = self._calc_spec_decode_metadata(
-                num_draft_tokens, cu_num_tokens)
+                num_draft_tokens, cu_num_tokens
+            )
             logits_indices = spec_decode_metadata.logits_indices
             num_sampled_tokens = num_draft_tokens + 1
 
@@ -1102,40 +1234,52 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         logits_indices_padded = None
         if self.cache_config.kv_sharing_fast_prefill:
             logits_indices_padded = self._prepare_kv_sharing_fast_prefill(
-                logits_indices)
+                logits_indices
+            )
 
         attn_metadata: dict[str, Any] = {}
 
         # Used in the below loop.
-        query_start_loc_cpu = self.query_start_loc.cpu[:num_reqs + 1]
+        query_start_loc_cpu = self.query_start_loc.cpu[: num_reqs + 1]
         seq_lens = self.seq_lens.gpu[:num_reqs]
         max_seq_len = self.seq_lens.np[:num_reqs].max().item()
         seq_lens_cpu = self.seq_lens.cpu[:num_reqs]
         num_computed_tokens_cpu = (
-            self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs])
+            self.input_batch.num_computed_tokens_cpu_tensor[:num_reqs]
+        )
         spec_decode_common_attn_metadata = None
         if use_spec_decode:
             self.num_accepted_tokens.np[:num_reqs] = (
-                self.input_batch.num_accepted_tokens_cpu[:num_reqs])
+                self.input_batch.num_accepted_tokens_cpu[:num_reqs]
+            )
             self.num_accepted_tokens.np[num_reqs:].fill(1)
             self.num_accepted_tokens.copy_to_gpu()
 
         max_num_scheduled_tokens = int(num_scheduled_tokens.max())
-        batch_bucket_size = \
-            self.bucketing_manager.find_decode_batch_bucket(num_reqs)
+        batch_bucket_size = self.bucketing_manager.find_decode_batch_bucket(
+            num_reqs
+        )
 
-        (batch_bucket_size, num_padded_tokens, num_tokens_across_dp) = \
-            self.get_dp_padding(total_num_scheduled_tokens, batch_bucket_size,
-                                num_padded_tokens, bool(self.is_prefills()[0]))
+        (batch_bucket_size, num_padded_tokens, num_tokens_across_dp) = (
+            self.get_dp_padding(
+                total_num_scheduled_tokens,
+                batch_bucket_size,
+                num_padded_tokens,
+                bool(self.is_prefills()[0]),
+            )
+        )
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
         for kv_cache_group_id, kv_cache_group_spec in enumerate(
-                self.kv_cache_config.kv_cache_groups):
+            self.kv_cache_config.kv_cache_groups
+        ):
             encoder_seq_lens = self._get_encoder_seq_lens(
-                scheduler_output, kv_cache_group_spec.kv_cache_spec, num_reqs)
+                scheduler_output, kv_cache_group_spec.kv_cache_spec, num_reqs
+            )
 
-            if isinstance(kv_cache_group_spec.kv_cache_spec,
-                          EncoderOnlyAttentionSpec):
+            if isinstance(
+                kv_cache_group_spec.kv_cache_spec, EncoderOnlyAttentionSpec
+            ):
                 # Encoder-only layers do not have KV cache, so we need to
                 # create a dummy block table and slot mapping for them.
                 blk_table_tensor = torch.zeros(
@@ -1144,7 +1288,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     device=self.device,
                 )
                 slot_mapping = torch.zeros(
-                    (total_num_scheduled_tokens, ),
+                    (total_num_scheduled_tokens,),
                     dtype=torch.int64,
                     device=self.device,
                 )
@@ -1152,13 +1296,15 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 blk_table = self.input_batch.block_table[kv_cache_group_id]
                 blk_table_tensor = blk_table.get_device_tensor(num_reqs)
-                slot_mapping = blk_table.slot_mapping.gpu[:
-                                                          total_num_scheduled_tokens]
+                slot_mapping = blk_table.slot_mapping.gpu[
+                    :total_num_scheduled_tokens
+                ]
 
                 # Fill unused with -1. Needed for reshape_and_cache in full cuda
                 # graph mode. `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
-                slot_mapping[total_num_scheduled_tokens:
-                             total_num_scheduled_tokens].fill_(-1)
+                slot_mapping[
+                    total_num_scheduled_tokens:total_num_scheduled_tokens
+                ].fill_(-1)
                 blk_table_tensor[num_reqs:total_num_scheduled_tokens].fill_(-1)
 
             common_attn_metadata = CommonAttentionMetadata(
@@ -1179,8 +1325,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 encoder_seq_lens=encoder_seq_lens,
             )
 
-            if self.speculative_config and \
-                spec_decode_common_attn_metadata is None:
+            if (
+                self.speculative_config
+                and spec_decode_common_attn_metadata is None
+            ):
                 spec_decode_common_attn_metadata = common_attn_metadata
 
             for attn_group in self.attn_groups[kv_cache_group_id]:
@@ -1196,23 +1344,27 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
 
                 extra_attn_metadata_args = {}
-                if use_spec_decode and isinstance(builder,
-                                                  GDNAttentionMetadataBuilder):
+                if use_spec_decode and isinstance(
+                    builder, GDNAttentionMetadataBuilder
+                ):
                     extra_attn_metadata_args = dict(
-                        num_accepted_tokens=self.num_accepted_tokens.
-                        gpu[:num_reqs],
+                        num_accepted_tokens=self.num_accepted_tokens.gpu[
+                            :num_reqs
+                        ],
                         num_draft_tokens=self.num_draft_tokens.gpu[:num_reqs],
                     )
 
                 if isinstance(builder, RBLNFlashAttentionMetadataBuilder):
-                    extra_attn_metadata_args["num_tokens"] = \
+                    extra_attn_metadata_args["num_tokens"] = (
                         self.input_batch.num_tokens_no_spec
+                    )
                     extra_attn_metadata_args["positions"] = self.positions.cpu
                     extra_attn_metadata_args["batch_pad"] = batch_bucket_size
                 attn_metadata_i = builder.build(
                     common_prefix_len=common_prefix_len,
                     common_attn_metadata=common_attn_metadata,
-                    **extra_attn_metadata_args)
+                    **extra_attn_metadata_args,
+                )
 
                 for layer_name in attn_group.layer_names:
                     attn_metadata[layer_name] = attn_metadata_i
@@ -1221,14 +1373,23 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if self.lora_config:
             assert (
                 np.sum(num_sampled_tokens)
-                <= self.vllm_config.scheduler_config.max_num_batched_tokens)
-            self.set_active_loras(self.input_batch, num_scheduled_tokens,
-                                  num_sampled_tokens)
+                <= self.vllm_config.scheduler_config.max_num_batched_tokens
+            )
+            self.set_active_loras(
+                self.input_batch, num_scheduled_tokens, num_sampled_tokens
+            )
 
-        return (attn_metadata, logits_indices, spec_decode_metadata,
-                num_scheduled_tokens, spec_decode_common_attn_metadata,
-                max_num_scheduled_tokens, batch_bucket_size, num_padded_tokens,
-                num_tokens_across_dp)
+        return (
+            attn_metadata,
+            logits_indices,
+            spec_decode_metadata,
+            num_scheduled_tokens,
+            spec_decode_common_attn_metadata,
+            max_num_scheduled_tokens,
+            batch_bucket_size,
+            num_padded_tokens,
+            num_tokens_across_dp,
+        )
 
     def _compile_model(self, model):
         TP = get_tp_group()
@@ -1250,9 +1411,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             "guard_filter_fn": torch.compiler.keep_tensor_guards_unsafe,
         }
         if not envs.VLLM_DISABLE_COMPILE_CACHE:
-            logger.info("Once the model is compiled for the first time, "
-                        "the cached compiled binary will be reused.")
-            options["cache_dir"] = os.path.join(envs.VLLM_CACHE_ROOT, 'rbln')
+            logger.info(
+                "Once the model is compiled for the first time, "
+                "the cached compiled binary will be reused."
+            )
+            options["cache_dir"] = os.path.join(envs.VLLM_CACHE_ROOT, "rbln")
         if envs.VLLM_RBLN_COMPILE_STRICT_MODE:
             options["mode"] = "strict"
 
@@ -1295,10 +1458,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Step 1. cu_num_sampled_tokens: [4, 5, 8, 9, 11]
         # arange: [0, 1, 2, 3, 0, 0, 1, 2, 0, 0, 1]
         cu_num_sampled_tokens, arange = self._get_cumsum_and_arange(
-            num_sampled_tokens, cumsum_dtype=np.int32)
+            num_sampled_tokens, cumsum_dtype=np.int32
+        )
         # Step 2. [0, 0, 0, 0, 103, 104, 104, 104, 206, 207, 207]
         logits_indices = np.repeat(
-            cu_num_scheduled_tokens - num_sampled_tokens, num_sampled_tokens)
+            cu_num_scheduled_tokens - num_sampled_tokens, num_sampled_tokens
+        )
         # Step 3. [0, 1, 2, 3, 103, 104, 105, 106, 206, 207, 208]
         logits_indices += arange
 
@@ -1309,24 +1474,31 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # cu_num_draft_tokens: [3, 3, 5, 5, 6]
         # arange: [0, 1, 2, 0, 1, 0]
         cu_num_draft_tokens, arange = self._get_cumsum_and_arange(
-            num_draft_tokens, cumsum_dtype=np.int32)
+            num_draft_tokens, cumsum_dtype=np.int32
+        )
         # [0, 0, 0, 5, 5, 9]
         target_logits_indices = np.repeat(
-            cu_num_sampled_tokens - num_sampled_tokens, num_draft_tokens)
+            cu_num_sampled_tokens - num_sampled_tokens, num_draft_tokens
+        )
         # [0, 1, 2, 5, 6, 9]
         target_logits_indices += arange
 
         # TODO: Optimize the CPU -> GPU copy.
         cu_num_draft_tokens = torch.from_numpy(cu_num_draft_tokens).to(
-            self.device, non_blocking=True)
+            self.device, non_blocking=True
+        )
         cu_num_sampled_tokens = torch.from_numpy(cu_num_sampled_tokens).to(
-            self.device, non_blocking=True)
-        logits_indices = torch.from_numpy(logits_indices).to(self.device,
-                                                             non_blocking=True)
+            self.device, non_blocking=True
+        )
+        logits_indices = torch.from_numpy(logits_indices).to(
+            self.device, non_blocking=True
+        )
         target_logits_indices = torch.from_numpy(target_logits_indices).to(
-            self.device, non_blocking=True)
+            self.device, non_blocking=True
+        )
         bonus_logits_indices = torch.from_numpy(bonus_logits_indices).to(
-            self.device, non_blocking=True)
+            self.device, non_blocking=True
+        )
 
         # Compute the draft token ids.
         # draft_token_indices:      [  1,   2,   3, 105, 106, 208]
@@ -1368,21 +1540,26 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         supported_tasks = list(model.pooler.get_supported_tasks())
 
-        if (self.scheduler_config.enable_chunked_prefill
-                and "encode" in supported_tasks):
+        if (
+            self.scheduler_config.enable_chunked_prefill
+            and "encode" in supported_tasks
+        ):
             supported_tasks.remove("encode")
 
-            logger.debug_once("Chunked prefill is not supported with "
-                              "encode task which using ALL pooling. "
-                              "Please turn off chunked prefill by "
-                              "`--no-enable-chunked-prefill` before using it.")
+            logger.debug_once(
+                "Chunked prefill is not supported with "
+                "encode task which using ALL pooling. "
+                "Please turn off chunked prefill by "
+                "`--no-enable-chunked-prefill` before using it."
+            )
 
         if "score" in supported_tasks:
             num_labels = getattr(self.model_config.hf_config, "num_labels", 0)
             if num_labels != 1:
                 supported_tasks.remove("score")
                 logger.debug_once(
-                    "Score API is only enabled for num_labels == 1.")
+                    "Score API is only enabled for num_labels == 1."
+                )
 
         return supported_tasks
 
@@ -1405,8 +1582,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     ) -> IntermediateTensors:
         # FIXME - RBLN does not support intermediate tensor slicing
         tp = self.vllm_config.parallel_config.tensor_parallel_size
-        enabled_sp = self.compilation_config.pass_config. \
-            enable_sequence_parallelism
+        enabled_sp = (
+            self.compilation_config.pass_config.enable_sequence_parallelism
+        )
 
         if intermediate_tensors is None:
             # for warm_up, from empty dummy intermediate tensors
@@ -1418,63 +1596,74 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # When sequence parallelism is enabled, we always pad num_tokens
                 # to be a multiple of tensor_parallel_size (tp) earlier
                 assert num_tokens % tp == 0
-            residual_scatter = tp > 1 and enabled_sp \
-                and num_tokens % tp == 0
+            residual_scatter = tp > 1 and enabled_sp and num_tokens % tp == 0
             assert not enabled_sp, "RBLN warm_up = !sp(sequence_parallel)"
             assert not residual_scatter, "RBLN warm_up = !residual_scatter"
             assert not sync_self, "RBLN warm_up = !sync self(from dummy)"
-            return IntermediateTensors({
-                k: v.reshape((batch_size, seq_len, -1))
-                for k, v in self.intermediate_tensors.items()
-            })
+            return IntermediateTensors(
+                {
+                    k: v.reshape((batch_size, seq_len, -1))
+                    for k, v in self.intermediate_tensors.items()
+                }
+            )
         else:
             # for execution, from input intermediate tensors
             assert batch_size == -1
             assert seq_len == -1
             assert sync_self, "RBLN execute = sync self(from input)"
-            return IntermediateTensors({
-                k: v
-                for k, v in intermediate_tensors.items()
-            })
+            return IntermediateTensors(
+                {k: v for k, v in intermediate_tensors.items()}
+            )
 
     def get_dp_padding(
         self,
         num_tokens: int,
         batch_bucket_size: int,
         num_padded_tokens: int | None = None,
-        is_prefill: bool = False
+        is_prefill: bool = False,
     ) -> tuple[int, Optional[int], Optional[torch.Tensor]]:
         dp_size = self.vllm_config.parallel_config.data_parallel_size
         dp_rank = self.vllm_config.parallel_config.data_parallel_rank
 
         if dp_size == 1:
-            assert num_padded_tokens is None, \
+            assert num_padded_tokens is None, (
                 "num_padded_tokens should not be applied for non-DP case"
+            )
             return batch_bucket_size, num_padded_tokens, None
 
         if num_padded_tokens is not None:
-            assert self.specialized_moe_decode, \
-                "num_padded_tokens is only supported when " \
+            assert self.specialized_moe_decode, (
+                "num_padded_tokens is only supported when "
                 "specialized MOE decode is enabled"
-            assert num_padded_tokens == self.max_num_batched_tokens, \
+            )
+            assert num_padded_tokens == self.max_num_batched_tokens, (
                 "num_padded_tokens should be equal to max_num_batched_tokens"
-            assert not is_prefill, \
+            )
+            assert not is_prefill, (
                 "num_padded_tokens is only supported for decode stage"
+            )
             num_tokens_across_dp_cpu = RBLNDPMetadata.num_tokens_across_dp(
-                num_tokens, dp_size, dp_rank)
-            return (batch_bucket_size, num_padded_tokens,
-                    num_tokens_across_dp_cpu)
+                num_tokens, dp_size, dp_rank
+            )
+            return (
+                batch_bucket_size,
+                num_padded_tokens,
+                num_tokens_across_dp_cpu,
+            )
 
-        num_tokens_across_dp_cpu, max_decode_tokens = \
+        num_tokens_across_dp_cpu, max_decode_tokens = (
             RBLNDPMetadata.num_tokens_across_dp_with_max_decode_tokens(
-            num_tokens, dp_size, dp_rank, is_prefill)
+                num_tokens, dp_size, dp_rank, is_prefill
+            )
+        )
 
         any_prefill = max_decode_tokens is None
         if any_prefill or not self.specialized_moe_decode:
             num_padded_tokens = self.max_num_batched_tokens
         else:
             batch_bucket_size = self.bucketing_manager.find_decode_batch_bucket(
-                max_decode_tokens)
+                max_decode_tokens
+            )
             num_padded_tokens = batch_bucket_size
 
         return batch_bucket_size, num_padded_tokens, num_tokens_across_dp_cpu
@@ -1486,28 +1675,32 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_scheduled_tokens_np: np.ndarray,
         kv_connector_output: Optional[KVConnectorOutput],
     ) -> ModelRunnerOutput:
-        assert self.input_batch.num_reqs ==\
-            len(self.input_batch.pooling_params), \
-        "Either all or none of the requests in" \
-        " a batch must be pooling request"
+        assert self.input_batch.num_reqs == len(
+            self.input_batch.pooling_params
+        ), (
+            "Either all or none of the requests in"
+            " a batch must be pooling request"
+        )
 
         hidden_states = hidden_states[:num_scheduled_tokens]
         pooling_metadata = self.input_batch.get_pooling_metadata()
-        pooling_metadata.build_pooling_cursor(num_scheduled_tokens_np.tolist(),
-                                              device=hidden_states.device)
-        seq_lens_cpu = self.seq_lens.cpu[:self.input_batch.num_reqs]
+        pooling_metadata.build_pooling_cursor(
+            num_scheduled_tokens_np.tolist(), device=hidden_states.device
+        )
+        seq_lens_cpu = self.seq_lens.cpu[: self.input_batch.num_reqs]
 
         # Pooling models D2H & synchronize occurs in pooler.py:build_output
         raw_pooler_output = self.model.pooler(
-            hidden_states=hidden_states, pooling_metadata=pooling_metadata)
+            hidden_states=hidden_states, pooling_metadata=pooling_metadata
+        )
 
         pooler_output: list[Optional[torch.Tensor]] = []
         for raw_output, seq_len, prompt_len in zip(
-                raw_pooler_output,
-                seq_lens_cpu,
-                pooling_metadata.prompt_lens,
-                strict=False):
-
+            raw_pooler_output,
+            seq_lens_cpu,
+            pooling_metadata.prompt_lens,
+            strict=False,
+        ):
             output = raw_output.data if seq_len == prompt_len else None
             pooler_output.append(output)
 
@@ -1524,17 +1717,24 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
     def _preprocess(
         self,
         scheduler_output: "SchedulerOutput",
-    ) -> tuple[int, Optional[torch.Tensor], Optional[torch.Tensor],
-               Optional[torch.Tensor], torch.Tensor,
-               Optional[IntermediateTensors], dict[str, Any]]:
-
+    ) -> tuple[
+        int,
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        Optional[torch.Tensor],
+        torch.Tensor,
+        Optional[IntermediateTensors],
+        dict[str, Any],
+    ]:
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
 
         # Pad tokens to multiple of tensor_parallel_size when
         # enabled collective fusion for SP
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        if self.compilation_config.pass_config. \
-            enable_sequence_parallelism and tp_size > 1:
+        if (
+            self.compilation_config.pass_config.enable_sequence_parallelism
+            and tp_size > 1
+        ):
             num_input_tokens = round_up(num_scheduled_tokens, tp_size)
         else:
             num_input_tokens = num_scheduled_tokens
@@ -1544,8 +1744,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # _prepare_inputs may reorder the batch, so we must gather multi
         # modal outputs after that to ensure the correct order
-        if (self.supports_mm_inputs and get_pp_group().is_first_rank
-                and not self.model_config.is_encoder_decoder):
+        if (
+            self.supports_mm_inputs
+            and get_pp_group().is_first_rank
+            and not self.model_config.is_encoder_decoder
+        ):
             # Run the multimodal encoder if any.
             self._execute_mm_encoder(scheduler_output)
             mm_embeds = self._gather_mm_embeddings(scheduler_output)
@@ -1560,7 +1763,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             # TODO(woosuk): Avoid the copy. Optimize.
             self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(
-                inputs_embeds_scheduled)
+                inputs_embeds_scheduled
+            )
 
             input_ids = None
             inputs_embeds = self.inputs_embeds.gpu[:num_input_tokens]
@@ -1581,8 +1785,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         else:
             positions = self.positions.gpu[:num_input_tokens]
 
-        if (self.model_config.is_encoder_decoder
-                and scheduler_output.scheduled_encoder_inputs):
+        if (
+            self.model_config.is_encoder_decoder
+            and scheduler_output.scheduled_encoder_inputs
+        ):
             encoder_inputs = self._extract_encoder_inputs(scheduler_output)
             model_kwargs.update(encoder_inputs)
 
@@ -1595,8 +1801,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         )
 
     def _sample(
-            self, logits: Optional[torch.Tensor],
-            spec_decode_metadata: Optional[SpecDecodeMetadata]
+        self,
+        logits: Optional[torch.Tensor],
+        spec_decode_metadata: Optional[SpecDecodeMetadata],
     ) -> SamplerOutput:
         # Sample the next token and get logprobs if needed.
         sampling_metadata = self.input_batch.sampling_metadata
@@ -1613,7 +1820,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 sampling_metadata,
             )
             self._update_states_after_model_execute(
-                sampler_output.sampled_token_ids)
+                sampler_output.sampled_token_ids
+            )
 
         return sampler_output
 
@@ -1628,9 +1836,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_kv_cache_groups = len(self.kv_cache_config.kv_cache_groups)
 
         logger.info("Warm up prefill graph")
-        prefill_seq_len = (self.scheduler_config.max_num_batched_tokens
-                           if self.scheduler_config.enable_chunked_prefill else
-                           self.model_config.max_model_len)
+        prefill_seq_len = (
+            self.scheduler_config.max_num_batched_tokens
+            if self.scheduler_config.enable_chunked_prefill
+            else self.model_config.max_model_len
+        )
         dummy_prefill_requests = []
         dummy_prefill_num_scheduled_tokens = {}
         self._add_dummy_requests(
@@ -1639,17 +1849,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             total_tokens=prefill_seq_len,
             num_computed_tokens=0,
             num_kv_cache_groups=num_kv_cache_groups,
-            sampling_params=None if self.is_pooling_model else SamplingParams(
-                temperature=0.0),
+            sampling_params=None
+            if self.is_pooling_model
+            else SamplingParams(temperature=0.0),
             pooling_params=PoolingParams(
-                task=self.get_supported_pooling_tasks()[0])
-            if self.is_pooling_model else None,
+                task=self.get_supported_pooling_tasks()[0]
+            )
+            if self.is_pooling_model
+            else None,
         )
         so, cso = self._make_dummy_scheduler_outputs(
-            dummy_prefill_requests, dummy_prefill_num_scheduled_tokens,
-            num_kv_cache_groups)
-        self._execute_dummy_requests(so, cso,
-                                     self.prefill_intermediate_tensors)
+            dummy_prefill_requests,
+            dummy_prefill_num_scheduled_tokens,
+            num_kv_cache_groups,
+        )
+        self._execute_dummy_requests(so, cso, self.prefill_intermediate_tensors)
 
         # compile decode graph
         for batch_bucket_size in self.bucketing_manager.decode_batch_buckets:
@@ -1657,30 +1871,40 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
             dummy_decode_requests = []
             dummy_decode_num_scheduled_tokens = {}
-            num_speculative_tokens = \
-            self.speculative_config.num_speculative_tokens \
-                if self.speculative_config is not None else 0
+            num_speculative_tokens = (
+                self.speculative_config.num_speculative_tokens
+                if self.speculative_config is not None
+                else 0
+            )
             for _ in range(batch_bucket_size):
                 self._add_dummy_requests(
                     requests=dummy_decode_requests,
                     num_scheduled_tokens=dummy_decode_num_scheduled_tokens,
-                    total_tokens=decode_max_seq_len - 1 -
-                    num_speculative_tokens,
-                    num_computed_tokens=decode_max_seq_len - 1 -
-                    num_speculative_tokens,
+                    total_tokens=decode_max_seq_len
+                    - 1
+                    - num_speculative_tokens,
+                    num_computed_tokens=decode_max_seq_len
+                    - 1
+                    - num_speculative_tokens,
                     num_kv_cache_groups=num_kv_cache_groups,
-                    sampling_params=None if self.is_pooling_model else
-                    SamplingParams(temperature=0.0),
+                    sampling_params=None
+                    if self.is_pooling_model
+                    else SamplingParams(temperature=0.0),
                     pooling_params=PoolingParams(
-                        task=self.get_supported_pooling_tasks()[0])
-                    if self.is_pooling_model else None,
+                        task=self.get_supported_pooling_tasks()[0]
+                    )
+                    if self.is_pooling_model
+                    else None,
                     num_speculative_tokens=num_speculative_tokens,
                 )
             so, cso = self._make_dummy_scheduler_outputs(
-                dummy_decode_requests, dummy_decode_num_scheduled_tokens,
-                num_kv_cache_groups)
-            current_intermediate_tensors = \
-                self.decode_intermediate_tensors.get(batch_bucket_size)
+                dummy_decode_requests,
+                dummy_decode_num_scheduled_tokens,
+                num_kv_cache_groups,
+            )
+            current_intermediate_tensors = self.decode_intermediate_tensors.get(
+                batch_bucket_size
+            )
             assert current_intermediate_tensors is not None
 
             if self.specialized_moe_decode:
@@ -1688,7 +1912,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     so,
                     cso,
                     current_intermediate_tensors,
-                    num_padded_tokens=self.max_num_batched_tokens)
+                    num_padded_tokens=self.max_num_batched_tokens,
+                )
 
             self._execute_dummy_requests(so, cso, current_intermediate_tensors)
 
@@ -1704,9 +1929,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_speculative_tokens: int = 0,
         block_id: int = 0,
     ) -> None:
-        num_blocks = round_up(
-            total_tokens,
-            self.cache_config.block_size) // self.cache_config.block_size
+        num_blocks = (
+            round_up(total_tokens, self.cache_config.block_size)
+            // self.cache_config.block_size
+        )
         prompt_token_ids = list(range(total_tokens))
 
         req = NewRequestData(
@@ -1715,18 +1941,22 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             mm_features=[],
             sampling_params=sampling_params,
             pooling_params=pooling_params,
-            block_ids=([block_id] * num_blocks, ) * num_kv_cache_groups,
+            block_ids=([block_id] * num_blocks,) * num_kv_cache_groups,
             num_computed_tokens=num_computed_tokens,
             lora_request=None,
         )
         requests.append(req)
-        num_scheduled_tokens[req.req_id] = (1 + num_speculative_tokens) \
-            if total_tokens - num_computed_tokens == 0 \
-                else total_tokens - num_computed_tokens
+        num_scheduled_tokens[req.req_id] = (
+            (1 + num_speculative_tokens)
+            if total_tokens - num_computed_tokens == 0
+            else total_tokens - num_computed_tokens
+        )
 
     def _make_dummy_scheduler_outputs(
-            self, requests: list[NewRequestData],
-            num_scheduled_tokens: dict[str, int], num_kv_cache_groups: int
+        self,
+        requests: list[NewRequestData],
+        num_scheduled_tokens: dict[str, int],
+        num_kv_cache_groups: int,
     ) -> tuple[SchedulerOutput, SchedulerOutput]:
         sched_output = SchedulerOutput(
             scheduled_new_reqs=requests,
@@ -1748,8 +1978,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             scheduled_spec_decode_tokens={},
             scheduled_encoder_inputs={},
             num_common_prefix_blocks=[1] * num_kv_cache_groups,
-            finished_req_ids={req.req_id
-                              for req in requests},
+            finished_req_ids={req.req_id for req in requests},
             free_encoder_mm_hashes=[],
             kv_connector_metadata=None,
         )
@@ -1765,17 +1994,20 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if get_pp_group().is_first_rank:
             intermediate_tensors = None
 
-        output = self.execute_model(sched_output, intermediate_tensors,
-                                    num_padded_tokens)
+        output = self.execute_model(
+            sched_output, intermediate_tensors, num_padded_tokens
+        )
         if output is None:
             self.sample_tokens(None)
-        output = self.execute_model(cleanup_sched_output, intermediate_tensors,
-                                    num_padded_tokens)
+        output = self.execute_model(
+            cleanup_sched_output, intermediate_tensors, num_padded_tokens
+        )
         if output is None:
             self.sample_tokens(None)
 
-    def _update_dummy_states(self, scheduler_output: SchedulerOutput,
-                             input_batch: InputBatch) -> None:
+    def _update_dummy_states(
+        self, scheduler_output: SchedulerOutput, input_batch: InputBatch
+    ) -> None:
         reqs_to_add: list[CachedRequestState] = []
         # Add new requests to the cached states.
         for new_req_data in scheduler_output.scheduled_new_reqs:
@@ -1828,19 +2060,21 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Get request indices.
         # E.g., [2, 5, 3] -> [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]
-        req_indices = np.repeat(self.arange_np[:num_reqs],
-                                num_scheduled_tokens)
+        req_indices = np.repeat(self.arange_np[:num_reqs], num_scheduled_tokens)
 
         # cu_num_tokens: [2, 5, 3] -> [2, 7, 10]
         # arange: [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         cu_num_tokens, arange = self._get_cumsum_and_arange(
-            num_scheduled_tokens)
+            num_scheduled_tokens
+        )
 
         # Get positions.
         positions_np = self.positions.np[:total_num_scheduled_tokens]
-        np.add(input_batch.num_computed_tokens_cpu[req_indices],
-               arange,
-               out=positions_np)
+        np.add(
+            input_batch.num_computed_tokens_cpu[req_indices],
+            arange,
+            out=positions_np,
+        )
         positions_np = positions_np.copy()
         positions = self.positions.cpu.clone()
 
@@ -1848,45 +2082,50 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # E.g., [0, 1, 0, 1, 2, 3, 4, 0, 1, 2]
         # -> [0, 1, M, M + 1, M + 2, M + 3, M + 4, 2 * M, 2 * M + 1, 2 * M + 2]
         # where M is the max_model_len.
-        token_indices = (positions_np +
-                         req_indices * input_batch.token_ids_cpu.shape[1])
+        token_indices = (
+            positions_np + req_indices * input_batch.token_ids_cpu.shape[1]
+        )
 
         input_ids = self.input_ids.cpu.clone()
         # NOTE(woosuk): We use torch.index_select instead of np.take here
         # because torch.index_select is much faster than np.take for large
         # tensors.
-        torch.index_select(input_batch.token_ids_cpu_tensor.flatten(),
-                           0,
-                           torch.from_numpy(token_indices),
-                           out=input_ids[:total_num_scheduled_tokens])
+        torch.index_select(
+            input_batch.token_ids_cpu_tensor.flatten(),
+            0,
+            torch.from_numpy(token_indices),
+            out=input_ids[:total_num_scheduled_tokens],
+        )
 
         input_batch.block_table.compute_slot_mapping(req_indices, positions_np)
         input_batch.block_table.commit_slot_mapping(total_num_scheduled_tokens)
 
         query_start_loc_np = self.query_start_loc.np.copy()
         query_start_loc_np[0] = 0
-        query_start_loc_np[1:num_reqs + 1] = cu_num_tokens
+        query_start_loc_np[1 : num_reqs + 1] = cu_num_tokens
         # Note: pad query_start_loc to be non-decreasing, as kernels
         # like FlashAttention requires that
-        query_start_loc_np[num_reqs + 1:].fill(cu_num_tokens[-1])
-        query_start_loc = torch.tensor(query_start_loc_np,
-                                       dtype=torch.int32)[:num_reqs + 1]
+        query_start_loc_np[num_reqs + 1 :].fill(cu_num_tokens[-1])
+        query_start_loc = torch.tensor(query_start_loc_np, dtype=torch.int32)[
+            : num_reqs + 1
+        ]
 
         seq_lens_np = self.seq_lens.np.copy()
         seq_lens_np[:num_reqs] = (
-            input_batch.num_computed_tokens_cpu[:num_reqs] +
-            num_scheduled_tokens)
+            input_batch.num_computed_tokens_cpu[:num_reqs]
+            + num_scheduled_tokens
+        )
         # Fill unused with 0 for full cuda graph mode.
         seq_lens_np[num_reqs:].fill(0)
         seq_lens = torch.tensor(seq_lens_np, dtype=torch.int32)[:num_reqs]
         max_seq_len = seq_lens_np[:num_reqs].max().item()
 
         # TODO: support spec_decode
-        use_spec_decode = len(
-            scheduler_output.scheduled_spec_decode_tokens) > 0
+        use_spec_decode = len(scheduler_output.scheduled_spec_decode_tokens) > 0
         if use_spec_decode:
             raise NotImplementedError(
-                "Spec decode is not supported for DP dummy run")
+                "Spec decode is not supported for DP dummy run"
+            )
 
         logits_indices = query_start_loc[1:] - 1
 
@@ -1895,8 +2134,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Used in the below loop.
         query_start_loc_cpu = query_start_loc
         seq_lens_cpu = seq_lens
-        num_computed_tokens_cpu = (
-            input_batch.num_computed_tokens_cpu_tensor[:num_reqs])
+        num_computed_tokens_cpu = input_batch.num_computed_tokens_cpu_tensor[
+            :num_reqs
+        ]
 
         attn_metadata_bucket: dict[int, dict[str, Any]] = {}
         input_ids_bucket: dict[int, torch.Tensor] = {}
@@ -1907,27 +2147,33 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # Prepare the attention metadata for each KV cache group and
             # make layers in the same group share the same metadata.
             for kv_cache_group_id, kv_cache_group_spec in enumerate(
-                    self.kv_cache_config.kv_cache_groups):
+                self.kv_cache_config.kv_cache_groups
+            ):
                 encoder_seq_lens = None
 
-                if isinstance(kv_cache_group_spec.kv_cache_spec,
-                              EncoderOnlyAttentionSpec):
+                if isinstance(
+                    kv_cache_group_spec.kv_cache_spec, EncoderOnlyAttentionSpec
+                ):
                     raise NotImplementedError(
                         "Encoder-only attention is not supported for "
-                        "DP dummy run")
+                        "DP dummy run"
+                    )
                 else:
                     blk_table = input_batch.block_table[kv_cache_group_id]
                     blk_table_tensor = blk_table.get_device_tensor(num_reqs)
-                    slot_mapping = \
-                        blk_table.slot_mapping.gpu[:total_num_scheduled_tokens]
+                    slot_mapping = blk_table.slot_mapping.gpu[
+                        :total_num_scheduled_tokens
+                    ]
 
                     # Fill unused with -1.
                     # Needed for reshape_and_cache in full cuda graph mode.
                     # `blk_table_tensor` -1 to match mamba PAD_SLOT_ID
-                    slot_mapping[total_num_scheduled_tokens:
-                                 total_num_scheduled_tokens].fill_(-1)
-                    blk_table_tensor[
-                        num_reqs:total_num_scheduled_tokens].fill_(-1)
+                    slot_mapping[
+                        total_num_scheduled_tokens:total_num_scheduled_tokens
+                    ].fill_(-1)
+                    blk_table_tensor[num_reqs:total_num_scheduled_tokens].fill_(
+                        -1
+                    )
 
                 common_attn_metadata = CommonAttentionMetadata(
                     query_start_loc=query_start_loc,
@@ -1954,20 +2200,24 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     if self.cascade_attn_enabled:
                         raise NotImplementedError(
                             "Cascade attention is not supported "
-                            "for DP dummy run")
+                            "for DP dummy run"
+                        )
 
                     extra_attn_metadata_args = {}
 
                     if isinstance(builder, RBLNFlashAttentionMetadataBuilder):
-                        extra_attn_metadata_args["num_tokens"] = \
+                        extra_attn_metadata_args["num_tokens"] = (
                             input_batch.num_tokens
+                        )
                         extra_attn_metadata_args["positions"] = positions
-                        extra_attn_metadata_args[
-                            "batch_pad"] = batch_bucket_size
+                        extra_attn_metadata_args["batch_pad"] = (
+                            batch_bucket_size
+                        )
                     attn_metadata_i = builder.build(
                         common_prefix_len=common_prefix_len,
                         common_attn_metadata=common_attn_metadata,
-                        **extra_attn_metadata_args)
+                        **extra_attn_metadata_args,
+                    )
 
                     for layer_name in attn_group.layer_names:
                         attn_metadata[layer_name] = attn_metadata_i
@@ -1989,15 +2239,18 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             input_ids_bucket[batch_bucket_size] = input_ids
             positions_bucket[batch_bucket_size] = positions
 
-        return DummyRunState(attn_metadata=attn_metadata_bucket,
-                             num_input_tokens=num_input_tokens,
-                             input_ids=input_ids_bucket,
-                             positions=positions_bucket)
+        return DummyRunState(
+            attn_metadata=attn_metadata_bucket,
+            num_input_tokens=num_input_tokens,
+            input_ids=input_ids_bucket,
+            positions=positions_bucket,
+        )
 
     def _prepare_dummy_input_batch(self) -> InputBatch:
         logits_processors = self.model_config.logits_processors
         custom_logitsprocs: Sequence[Union[str, type[LogitsProcessor]]] = (
-            tuple(logits_processors) if logits_processors is not None else ())
+            tuple(logits_processors) if logits_processors is not None else ()
+        )
         dummy_input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
             # We need to use the encoder length for encoder-decoer
@@ -2021,25 +2274,26 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # processor uses output token ids so we set this conservatively.
             logitsprocs_need_output_token_ids=bool(custom_logitsprocs),
             is_pooling_model=self.is_pooling_model,
-            cp_kv_cache_interleave_size=self.parallel_config.
-            cp_kv_cache_interleave_size,
+            cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
         )
 
         block_sizes = [
             kv_cache_group.kv_cache_spec.block_size
             for kv_cache_group in self.kv_cache_config.kv_cache_groups
-            if not isinstance(kv_cache_group.kv_cache_spec,
-                              EncoderOnlyAttentionSpec)
+            if not isinstance(
+                kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec
+            )
         ]
         kernel_block_sizes = self.kernel_block_sizes
 
         if block_sizes != [
-                self.cache_config.block_size
+            self.cache_config.block_size
         ] or kernel_block_sizes != [self.cache_config.block_size]:
             assert self.cache_config.cpu_offload_gb == 0, (
                 "Cannot re-initialize the input batch when CPU weight "
                 "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501
-                "for more details.")
+                "for more details."
+            )
             dummy_input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=max(self.max_model_len, self.max_encoder_len),
@@ -2054,7 +2308,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 is_pooling_model=self.is_pooling_model,
                 num_speculative_tokens=(
                     self.vllm_config.speculative_config.num_speculative_tokens
-                    if self.vllm_config.speculative_config else 0),
+                    if self.vllm_config.speculative_config
+                    else 0
+                ),
             )
 
         return dummy_input_batch
@@ -2065,10 +2321,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         #       and encoder-only attention
         if self.is_pooling_model:
             raise NotImplementedError(
-                "Pooling model is not supported for DP dummy run")
+                "Pooling model is not supported for DP dummy run"
+            )
         if self.uses_mrope:
             raise NotImplementedError(
-                "M-RoPE is not supported for DP dummy run")
+                "M-RoPE is not supported for DP dummy run"
+            )
         if self.lora_config:
             raise NotImplementedError("LoRA is not supported for DP dummy run")
 
@@ -2081,54 +2339,66 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             total_tokens=1,
             num_computed_tokens=1,
             num_kv_cache_groups=num_kv_cache_groups,
-            sampling_params=None if self.is_pooling_model else SamplingParams(
-                temperature=0.0),
+            sampling_params=None
+            if self.is_pooling_model
+            else SamplingParams(temperature=0.0),
             pooling_params=PoolingParams(
-                task=self.get_supported_pooling_tasks()[0])
-            if self.is_pooling_model else None,
+                task=self.get_supported_pooling_tasks()[0]
+            )
+            if self.is_pooling_model
+            else None,
             block_id=self.cache_config.num_gpu_blocks - 1,
         )
         dummy_run_scheduler_output, _ = self._make_dummy_scheduler_outputs(
-            dummy_run_requests, dummy_run_num_scheduled_tokens,
-            num_kv_cache_groups)
+            dummy_run_requests,
+            dummy_run_num_scheduled_tokens,
+            num_kv_cache_groups,
+        )
 
         dummy_input_batch = self._prepare_dummy_input_batch()
-        self._update_dummy_states(dummy_run_scheduler_output,
-                                  dummy_input_batch)
+        self._update_dummy_states(dummy_run_scheduler_output, dummy_input_batch)
         self.dummy_run_state = self._prepare_dummy_inputs(
-            dummy_run_scheduler_output, dummy_input_batch)
+            dummy_run_scheduler_output, dummy_input_batch
+        )
 
     @torch.inference_mode()
     def dummy_run(self) -> None:
-        (attn_metadata, num_input_tokens, input_ids,
-         positions) = self.dummy_run_state
+        (attn_metadata, num_input_tokens, input_ids, positions) = (
+            self.dummy_run_state
+        )
 
-        (batch_bucket_size, num_padded_tokens,
-         num_tokens_across_dp) = self.get_dp_padding(
-             num_input_tokens, self.bucketing_manager.decode_batch_buckets[0])
+        (batch_bucket_size, num_padded_tokens, num_tokens_across_dp) = (
+            self.get_dp_padding(
+                num_input_tokens, self.bucketing_manager.decode_batch_buckets[0]
+            )
+        )
 
         attn_metadata = attn_metadata.get(batch_bucket_size)
         input_ids = input_ids.get(batch_bucket_size)
         positions = positions.get(batch_bucket_size)
-        assert attn_metadata is not None \
-            and input_ids is not None \
-            and positions is not None, \
-            "attn_metadata, input_ids, and positions should be defined" \
+        assert (
+            attn_metadata is not None
+            and input_ids is not None
+            and positions is not None
+        ), (
+            "attn_metadata, input_ids, and positions should be defined"
             f" for batch_bucket_size: {batch_bucket_size}"
+        )
 
         if get_pp_group().is_first_rank:
             intermediate_tensors = None
         else:
-            intermediate_tensors = \
-                self.decode_intermediate_tensors.get(batch_bucket_size)
+            intermediate_tensors = self.decode_intermediate_tensors.get(
+                batch_bucket_size
+            )
             assert intermediate_tensors is not None
 
         with set_forward_context(
-                attn_metadata,
-                self.vllm_config,
-                num_tokens=num_input_tokens,
-                num_tokens_across_dp=num_tokens_across_dp,
-                num_padded_tokens=num_padded_tokens,
+            attn_metadata,
+            self.vllm_config,
+            num_tokens=num_input_tokens,
+            num_tokens_across_dp=num_tokens_across_dp,
+            num_padded_tokens=num_padded_tokens,
         ):
             token_indices = None
             inputs_embeds = None
@@ -2144,17 +2414,20 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             )
 
     def _bookkeeping_sync(
-        self, scheduler_output: "SchedulerOutput",
-        sampler_output: SamplerOutput, logits: Optional[torch.Tensor],
-        hidden_states: torch.Tensor, num_scheduled_tokens: int
+        self,
+        scheduler_output: "SchedulerOutput",
+        sampler_output: SamplerOutput,
+        logits: Optional[torch.Tensor],
+        hidden_states: torch.Tensor,
+        num_scheduled_tokens: int,
     ) -> tuple[
-            dict[str, int],
-            Optional[LogprobsLists],
-            list[list[int]],
-            dict[str, Optional[LogprobsTensors]],
-            list[str],
-            dict[str, int],
-            list[int],
+        dict[str, int],
+        Optional[LogprobsLists],
+        list[list[int]],
+        dict[str, Optional[LogprobsTensors]],
+        list[str],
+        dict[str, int],
+        list[int],
     ]:
         num_nans_in_logits = {}
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
@@ -2165,8 +2438,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         discard_sampled_tokens_req_indices = []
         for i, req_id in enumerate(self.input_batch.req_ids):
             req_state = self.requests[req_id]
-            seq_len = (req_state.num_computed_tokens +
-                       scheduler_output.num_scheduled_tokens[req_id])
+            seq_len = (
+                req_state.num_computed_tokens
+                + scheduler_output.num_scheduled_tokens[req_id]
+            )
             if seq_len < req_state.num_tokens:
                 # Ignore the sampled token for partial prefills.
                 # Rewind the generator state as if the token was not sampled.
@@ -2181,14 +2456,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # Copy some objects so they don't get modified after returning.
         # This is important when using async scheduling.
         req_ids_output_copy = self.input_batch.req_ids.copy()
-        req_id_to_index_output_copy = \
-            self.input_batch.req_id_to_index.copy()
+        req_id_to_index_output_copy = self.input_batch.req_id_to_index.copy()
 
         # NOTE: GPU -> CPU Sync happens here.
         # Move as many CPU operations as possible before this sync point.
         logprobs_tensors = sampler_output.logprobs_tensors
-        logprobs_lists = logprobs_tensors.tolists() \
-            if logprobs_tensors is not None else None
+        logprobs_lists = (
+            logprobs_tensors.tolists() if logprobs_tensors is not None else None
+        )
 
         # Compute prompt logprobs if needed.
         prompt_logprobs_dict = self._get_prompt_logprobs_dict(
@@ -2207,11 +2482,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 valid_sampled_token_ids = self._to_list(sampled_token_ids)
             else:
                 # Includes spec decode tokens.
-                valid_sampled_token_ids, _ = \
+                valid_sampled_token_ids, _ = (
                     self.rejection_sampler.parse_output(
                         sampled_token_ids,
                         self.input_batch.vocab_size,
                     )
+                )
             # Mask out the sampled tokens that should not be sampled.
             for i in discard_sampled_tokens_req_indices:
                 if i < len(valid_sampled_token_ids):
@@ -2225,10 +2501,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # Cache the sampled tokens on the GPU and avoid CPU sync.
             # These will be copied into input_ids in the next step
             # when preparing inputs.
-            self.input_batch.prev_sampled_token_ids = \
-                sampled_token_ids
-            self.input_batch.prev_sampled_token_ids_invalid_indices = \
+            self.input_batch.prev_sampled_token_ids = sampled_token_ids
+            self.input_batch.prev_sampled_token_ids_invalid_indices = (
                 invalid_req_indices_set
+            )
             self.input_batch.prev_req_id_to_index = {
                 req_id: i
                 for i, req_id in enumerate(self.input_batch.req_ids)
@@ -2243,8 +2519,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         req_ids = self.input_batch.req_ids
         for req_idx in range(num_sampled_tokens):
             if self.use_async_scheduling:
-                sampled_ids = [-1] if \
-                    req_idx not in invalid_req_indices_set else None
+                sampled_ids = (
+                    [-1] if req_idx not in invalid_req_indices_set else None
+                )
             else:
                 sampled_ids = valid_sampled_token_ids[req_idx]
             if not sampled_ids:
@@ -2255,10 +2532,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             assert end_idx <= self.max_model_len, (
                 "Sampled token IDs exceed the max model length. "
                 f"Total number of tokens: {end_idx} > max_model_len: "
-                f"{self.max_model_len}")
+                f"{self.max_model_len}"
+            )
 
-            self.input_batch.token_ids_cpu[req_idx,
-                                           start_idx:end_idx] = sampled_ids
+            self.input_batch.token_ids_cpu[req_idx, start_idx:end_idx] = (
+                sampled_ids
+            )
             self.input_batch.num_tokens_no_spec[req_idx] = end_idx
             self.input_batch.num_tokens[req_idx] = end_idx
 
@@ -2284,8 +2563,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         num_padded_tokens: int | None = None,
     ) -> Union[ModelRunnerOutput, IntermediateTensors, None]:
         if self.execute_model_state is not None:
-            raise RuntimeError("State error: sample_tokens() must be called "
-                               "after execute_model() returns None.")
+            raise RuntimeError(
+                "State error: sample_tokens() must be called "
+                "after execute_model() returns None."
+            )
         num_scheduled_tokens = scheduler_output.total_num_scheduled_tokens
         with record_function_or_nullcontext("Preprocess"):
             self._update_states(scheduler_output)
@@ -2293,29 +2574,37 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 if not has_kv_transfer_group():
                     # Return empty ModelRunnerOutput if there's no work to do.
                     return EMPTY_MODEL_RUNNER_OUTPUT
-                return self.kv_connector_no_forward(scheduler_output,
-                                                    self.vllm_config)
+                return self.kv_connector_no_forward(
+                    scheduler_output, self.vllm_config
+                )
             if self.cache_config.kv_sharing_fast_prefill:
                 assert not self.num_prompt_logprobs, (
                     "--kv-sharing-fast-prefill produces incorrect logprobs for "
                     "prompt tokens, tokens, please disable it when the requests"
-                    " need prompt logprobs")
+                    " need prompt logprobs"
+                )
 
             num_reqs = self.input_batch.num_reqs
             req_ids = self.input_batch.req_ids
-            tokens = [
-                scheduler_output.num_scheduled_tokens[i] for i in req_ids
-            ]
+            tokens = [scheduler_output.num_scheduled_tokens[i] for i in req_ids]
             num_scheduled_tokens_np = np.array(tokens, dtype=np.int32)
             # max_num_scheduled_tokens = int(num_scheduled_tokens_np.max())
             # num_tokens_unpadded = scheduler_output.total_num_scheduled_tokens
 
             # Prepare the decoder inputs.
-            (attn_metadata, logits_indices, spec_decode_metadata,
-             num_scheduled_tokens_np, spec_decode_common_attn_metadata,
-             max_query_len, batch_bucket_size, num_padded_tokens,
-             num_tokens_across_dp) = self._prepare_inputs(
-                 scheduler_output, num_scheduled_tokens_np, num_padded_tokens)
+            (
+                attn_metadata,
+                logits_indices,
+                spec_decode_metadata,
+                num_scheduled_tokens_np,
+                spec_decode_common_attn_metadata,
+                max_query_len,
+                batch_bucket_size,
+                num_padded_tokens,
+                num_tokens_across_dp,
+            ) = self._prepare_inputs(
+                scheduler_output, num_scheduled_tokens_np, num_padded_tokens
+            )
 
             (
                 num_input_tokens,
@@ -2327,32 +2616,41 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Padding for speculative decoding
         # in case of that all requests are not scheduled equally.
-        num_scheduled_tokens_per_req = torch.tensor([
-            scheduler_output.num_scheduled_tokens[i]
-            for i in self.input_batch.req_ids
-        ],
-                                                    device=input_ids.device,
-                                                    dtype=torch.int32)
+        num_scheduled_tokens_per_req = torch.tensor(
+            [
+                scheduler_output.num_scheduled_tokens[i]
+                for i in self.input_batch.req_ids
+            ],
+            device=input_ids.device,
+            dtype=torch.int32,
+        )
         max_num_scheduled_tokens = torch.max(num_scheduled_tokens_per_req)
 
         if self.speculative_config is not None and not torch.all(
-                num_scheduled_tokens_per_req == max_num_scheduled_tokens):
+            num_scheduled_tokens_per_req == max_num_scheduled_tokens
+        ):
             input_ids = rbln_utils.pad_speculative_draft_tokens(
-                input_ids, num_scheduled_tokens_per_req)
+                input_ids, num_scheduled_tokens_per_req
+            )
             positions = rbln_utils.pad_speculative_draft_tokens(
-                positions, num_scheduled_tokens_per_req)
+                positions, num_scheduled_tokens_per_req
+            )
 
         # Run the model.
         # Use persistent buffers for CUDA graphs.
-        with (set_forward_context(
+        with (
+            set_forward_context(
                 attn_metadata,
                 self.vllm_config,
                 num_tokens=num_input_tokens,
                 num_tokens_across_dp=num_tokens_across_dp,
                 num_padded_tokens=num_padded_tokens,
-        ), record_function_or_nullcontext("Forward"),
-              self.maybe_get_kv_connector_output(scheduler_output) as
-              kv_connector_output):
+            ),
+            record_function_or_nullcontext("Forward"),
+            self.maybe_get_kv_connector_output(
+                scheduler_output
+            ) as kv_connector_output,
+        ):
             if attn_metadata is not None:
                 for attn_metadatum in attn_metadata.values():
                     attn_metadatum.kv_caches = self.kv_caches
@@ -2372,13 +2670,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # The prefill and decode cannot be mixed.
             assert len(is_prefills) > 0 and all(
                 is_prefill == is_prefills[0]
-                for is_prefill in is_prefills[:num_reqs])
+                for is_prefill in is_prefills[:num_reqs]
+            )
             if is_prefills[0]:
                 # prefill chunk padding
                 max_seq_len = int(self.seq_lens.np[:num_reqs].max())
-                prefill_size = (self.scheduler_config.max_num_batched_tokens
-                                if self.scheduler_config.enable_chunked_prefill
-                                else 1 << (math.ceil(math.log2(max_seq_len))))
+                prefill_size = (
+                    self.scheduler_config.max_num_batched_tokens
+                    if self.scheduler_config.enable_chunked_prefill
+                    else 1 << (math.ceil(math.log2(max_seq_len)))
+                )
                 input_ids = rbln_utils.pad(input_ids, -1, prefill_size)
                 positions = rbln_utils.pad(positions, -1, prefill_size)
             else:
@@ -2395,7 +2696,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.lora_config is not None:
                 lora_ids = [
                     self.requests[req_id].lora_request.lora_int_id
-                    if self.requests[req_id].lora_request is not None else 0
+                    if self.requests[req_id].lora_request is not None
+                    else 0
                     for req_id in self.input_batch.req_ids
                 ]
 
@@ -2447,9 +2749,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 ccl_time = None
 
                 if reports is not None and len(reports) > 0:
-                    host_time = reports[0].get('total_host', None)
-                    device_time = reports[0].get('total_device', None)
-                    ccl_time = reports[0].get('total_ccl', None)
+                    host_time = reports[0].get("total_host", None)
+                    device_time = reports[0].get("total_device", None)
+                    ccl_time = reports[0].get("total_ccl", None)
 
                 if is_prefills[0]:
                     self.performance_tracker.record_prefill(
@@ -2457,14 +2759,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         num_scheduled_tokens,
                         host_time=host_time,
                         device_time=device_time,
-                        ccl_time=ccl_time)
+                        ccl_time=ccl_time,
+                    )
                 else:
                     self.performance_tracker.record_decode(
                         execution_time,
                         num_scheduled_tokens,
                         host_time=host_time,
                         device_time=device_time,
-                        ccl_time=ccl_time)
+                        ccl_time=ccl_time,
+                    )
 
         with record_function_or_nullcontext("Postprocess"):
             if self.use_aux_hidden_state_outputs:
@@ -2479,9 +2783,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # NOTE: Overlapping micro-batches (CPP) is handled in
             # RBLNWorker via AsyncPPCommunicator for the mp backend.
             # https://github.com/vllm-project/vllm/issues/18019
-            broadcast_pp_output = \
-                self.parallel_config.distributed_executor_backend \
-                == "external_launcher" and len(get_pp_group().ranks) > 0
+            broadcast_pp_output = (
+                self.parallel_config.distributed_executor_backend
+                == "external_launcher"
+                and len(get_pp_group().ranks) > 0
+            )
             if not get_pp_group().is_last_rank:
                 # For mid-pipeline stages, return intermediate tensors
                 assert isinstance(hidden_states, IntermediateTensors)
@@ -2494,10 +2800,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 # for last-pipeline stages, return hidden states
                 if self.is_pooling_model:
-                    return self._pool(hidden_states.flatten(0, -2),
-                                      num_scheduled_tokens,
-                                      num_scheduled_tokens_np,
-                                      kv_connector_output)
+                    return self._pool(
+                        hidden_states.flatten(0, -2),
+                        num_scheduled_tokens,
+                        num_scheduled_tokens_np,
+                        kv_connector_output,
+                    )
                 sample_hidden_states = hidden_states
                 if not self.use_wrapped_compute_logits():
                     # DO NOT include compute logits
@@ -2522,11 +2830,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                         assert selected_token_indices.size(0) == 1
                         num_computed = self.input_batch.num_computed_tokens_cpu
                         num_prompted = self.input_batch.num_prompt_tokens
-                        is_last_prefill = (num_computed +
-                                           self.max_num_tokens) >= num_prompted
+                        is_last_prefill = (
+                            num_computed + self.max_num_tokens
+                        ) >= num_prompted
                         if not is_last_prefill[0]:
                             selected_token_indices = torch.tensor(
-                                [], dtype=selected_token_indices.dtype)
+                                [], dtype=selected_token_indices.dtype
+                            )
                             # chunked prefill(#0~#N-1, intermediate)
                             # token_indices = torch.tensor([max_num_seqs-1])
                             # selected = torch.tensor([])
@@ -2539,21 +2849,31 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     else:  # decode
                         # selected_token_indices is for valid decode tokens
                         # token_indices == None, selected = torch.tensor([0])
-                        batch_indices = torch.arange(self.input_batch.num_reqs,
-                                                     device=self.device)
+                        batch_indices = torch.arange(
+                            self.input_batch.num_reqs, device=self.device
+                        )
                         if self.speculative_config is not None:
                             sample_hidden_states = hidden_states[
-                                batch_indices, :self.speculative_config.
-                                num_speculative_tokens + 1]
+                                batch_indices,
+                                : self.speculative_config.num_speculative_tokens
+                                + 1,
+                            ]
                         logits = logits[selected_token_indices]
 
             if broadcast_pp_output:
-                model_output_broadcast_data = {
-                    "logits": logits.contiguous(),
-                } if logits is not None else {}
-                model_output_broadcast_data = get_pp_group(
-                ).broadcast_tensor_dict(model_output_broadcast_data,
-                                        src=len(get_pp_group().ranks) - 1)
+                model_output_broadcast_data = (
+                    {
+                        "logits": logits.contiguous(),
+                    }
+                    if logits is not None
+                    else {}
+                )
+                model_output_broadcast_data = (
+                    get_pp_group().broadcast_tensor_dict(
+                        model_output_broadcast_data,
+                        src=len(get_pp_group().ranks) - 1,
+                    )
+                )
                 assert model_output_broadcast_data is not None
                 logits = model_output_broadcast_data["logits"]
 
@@ -2597,8 +2917,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # to be float32 dtype for CPU tensors
             original_dtype = logits.dtype
             logits = logits.to(torch.float32)
-            apply_grammar_bitmask(scheduler_output, grammar_output,
-                                  self.input_batch, logits)
+            apply_grammar_bitmask(
+                scheduler_output, grammar_output, self.input_batch, logits
+            )
             logits = logits.to(original_dtype)
 
         with record_function_or_nullcontext("Sample"):
@@ -2620,19 +2941,25 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         spec_config = self.speculative_config
         use_padded_batch_for_eagle = (
-            spec_config is not None and spec_config.use_eagle()
-            and not spec_config.disable_padded_drafter_batch)
+            spec_config is not None
+            and spec_config.use_eagle()
+            and not spec_config.disable_padded_drafter_batch
+        )
         effective_drafter_max_model_len = self.max_model_len
         if effective_drafter_max_model_len is None:
             effective_drafter_max_model_len = self.model_config.max_model_len
-        if (spec_config is not None
-                and spec_config.draft_model_config is not None
-                and spec_config.draft_model_config.max_model_len is not None):
-            effective_drafter_max_model_len = \
+        if (
+            spec_config is not None
+            and spec_config.draft_model_config is not None
+            and spec_config.draft_model_config.max_model_len is not None
+        ):
+            effective_drafter_max_model_len = (
                 spec_config.draft_model_config.max_model_len
+            )
         input_fits_in_drafter = spec_decode_common_attn_metadata and (
             spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
-            <= effective_drafter_max_model_len)
+            <= effective_drafter_max_model_len
+        )
         if use_padded_batch_for_eagle:
             assert spec_config is not None
             assert isinstance(self.drafter, EagleProposer)
@@ -2659,8 +2986,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 scheduler_output.total_num_scheduled_tokens,
             )
 
-        if (self.speculative_config and not use_padded_batch_for_eagle
-                and input_fits_in_drafter):
+        if (
+            self.speculative_config
+            and not use_padded_batch_for_eagle
+            and input_fits_in_drafter
+        ):
             # ngram and other speculative decoding methods use the sampled
             # tokens on the CPU, so they are run after bookkeeping.
             propose_draft_token_ids(valid_sampled_token_ids)
@@ -2702,8 +3032,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return DraftTokenIds(req_ids, draft_token_ids)
 
     def _copy_valid_sampled_token_count(
-            self, next_token_ids: torch.Tensor,
-            valid_sampled_tokens_count: torch.Tensor) -> None:
+        self,
+        next_token_ids: torch.Tensor,
+        valid_sampled_tokens_count: torch.Tensor,
+    ) -> None:
         if self.valid_sampled_token_count_event is None:
             return
 
@@ -2712,10 +3044,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # prepare_input of draft model.
         with torch.cuda.stream(self.valid_sampled_token_count_copy_stream):
             self.valid_sampled_token_count_copy_stream.wait_stream(
-                default_stream)  # type: ignore
+                default_stream
+            )  # type: ignore
             counts = valid_sampled_tokens_count
             counts_cpu = self.valid_sampled_token_count_cpu
-            counts_cpu[:counts.shape[0]].copy_(counts, non_blocking=True)
+            counts_cpu[: counts.shape[0]].copy_(counts, non_blocking=True)
             self.valid_sampled_token_count_event.record()
 
         self.input_batch.prev_sampled_token_ids = next_token_ids.unsqueeze(1)
@@ -2747,8 +3080,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         elif spec_config.method == "suffix":
             assert isinstance(sampled_token_ids, list)
             assert isinstance(self.drafter, SuffixDecodingProposer)
-            draft_token_ids = self.drafter.propose(self.input_batch,
-                                                   sampled_token_ids)
+            draft_token_ids = self.drafter.propose(
+                self.input_batch, sampled_token_ids
+            )
         elif spec_config.method == "medusa":
             assert isinstance(sampled_token_ids, list)
             assert isinstance(self.drafter, MedusaProposer)
@@ -2760,11 +3094,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 indices = []
                 offset = 0
                 assert spec_decode_metadata is not None, (
-                    "No spec decode metadata for medusa")
+                    "No spec decode metadata for medusa"
+                )
                 for num_draft, tokens in zip(
-                        spec_decode_metadata.num_draft_tokens,
-                        sampled_token_ids,
-                        strict=False):
+                    spec_decode_metadata.num_draft_tokens,
+                    sampled_token_ids,
+                    strict=False,
+                ):
                     indices.append(offset + len(tokens) - 1)
                     offset += num_draft + 1
                 indices = torch.tensor(indices, device=self.device)
@@ -2778,10 +3114,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         elif spec_config.use_eagle():
             assert isinstance(self.drafter, EagleProposer)
             assert spec_config.disable_padded_drafter_batch is not True, (
-                "This option is not supported in vllm-rbln.")
-            assert isinstance(
-                sampled_token_ids,
-                torch.Tensor), ("sampled_token_ids should be a torch.Tensor.")
+                "This option is not supported in vllm-rbln."
+            )
+            assert isinstance(sampled_token_ids, torch.Tensor), (
+                "sampled_token_ids should be a torch.Tensor."
+            )
 
             next_token_ids, valid_sampled_tokens_count = (
                 self.drafter.prepare_next_token_ids_padded(
@@ -2790,9 +3127,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     self.requests,
                     self.input_batch,
                     self.discard_request_mask.gpu,
-                ))
-            self._copy_valid_sampled_token_count(next_token_ids,
-                                                 valid_sampled_tokens_count)
+                )
+            )
+            self._copy_valid_sampled_token_count(
+                next_token_ids, valid_sampled_tokens_count
+            )
 
             target_hidden_states = hidden_states
             if spec_decode_metadata is None:
@@ -2804,14 +3143,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     assert aux_hidden_states is not None
                     target_hidden_states = torch.cat(
                         [h.view(-1, h.shape[-1]) for h in aux_hidden_states],
-                        dim=-1)
+                        dim=-1,
+                    )
             else:
                 common_attn_metadata, token_indices_to_sample = (
                     self.drafter.prepare_inputs_padded(
                         common_attn_metadata,
                         spec_decode_metadata,
                         valid_sampled_tokens_count,
-                    ))
+                    )
+                )
                 total_num_tokens = common_attn_metadata.num_actual_tokens
                 # When padding the batch, token_indices is just a range
                 target_token_ids = self.input_ids.gpu[:total_num_tokens]
@@ -2820,7 +3161,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     assert aux_hidden_states is not None
                     target_hidden_states = torch.cat(
                         [h.view(-1, h.shape[-1]) for h in aux_hidden_states],
-                        dim=-1)
+                        dim=-1,
+                    )
 
             if self.supports_mm_inputs:
                 mm_embed_inputs = self._gather_mm_embeddings(
@@ -2850,28 +3192,35 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         if not hasattr(self, "model"):
             logger.info("Loading model from scratch...")
             self.model = model_loader.load_model(
-                vllm_config=self.vllm_config, model_config=self.model_config)
+                vllm_config=self.vllm_config, model_config=self.model_config
+            )
         else:
             logger.info(
-                "Model was already initialized. Loading weights inplace...")
-            model_loader.load_weights(self.model,
-                                      model_config=self.model_config)
+                "Model was already initialized. Loading weights inplace..."
+            )
+            model_loader.load_weights(
+                self.model, model_config=self.model_config
+            )
 
         self.model = self.get_model().eval()
         self.compute_logits_model = self.model
         if self.model_config.is_multimodal_model and hasattr(
-                self.model.get_language_model(), "logits_processor"):
+            self.model.get_language_model(), "logits_processor"
+        ):
             self.compute_logits_model = self.model.get_language_model()
-            self.logits_processor = self.model.get_language_model(
-            ).logits_processor
+            self.logits_processor = (
+                self.model.get_language_model().logits_processor
+            )
         elif hasattr(self.model, "logits_processor"):
             self.logits_processor = self.model.logits_processor
         else:
             self.logits_processor = None
 
         logger.info("load_model = %s", self.model)
-        logger.info("model_config.num_layers = %d",
-                    self.model_config.get_num_layers(self.parallel_config))
+        logger.info(
+            "model_config.num_layers = %d",
+            self.model_config.get_num_layers(self.parallel_config),
+        )
 
         def model_wrapper(
             input_ids: torch.Tensor,
@@ -2879,8 +3228,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             intermediate_tensors: Optional[IntermediateTensors] = None,
             inputs_embeds: Optional[torch.Tensor] = None,
             selected_token_indices: Optional[torch.Tensor] = None,
-        ) -> tuple[Union[torch.Tensor, IntermediateTensors],
-                   Optional[torch.Tensor]]:
+        ) -> tuple[
+            Union[torch.Tensor, IntermediateTensors], Optional[torch.Tensor]
+        ]:
             """
             This wrapper function is designed to be compiled by torch.compile.
             It handles the forward pass of the underlying model and, computes
@@ -2890,7 +3240,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 input_ids=input_ids,
                 positions=positions,
                 intermediate_tensors=intermediate_tensors,
-                inputs_embeds=inputs_embeds)
+                inputs_embeds=inputs_embeds,
+            )
 
             logits = None
             if self.use_aux_hidden_state_outputs:
@@ -2898,14 +3249,16 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             else:
                 hidden_states = model_output
 
-            if get_pp_group().is_last_rank \
-                and self.lora_config is None \
-                and (self.speculative_config is None \
-                     or self.speculative_config.method \
-                        not in ("eagle", "eagle3")) \
-                and not self.is_pooling_model \
-                and self.logits_processor is not None:
-
+            if (
+                get_pp_group().is_last_rank
+                and self.lora_config is None
+                and (
+                    self.speculative_config is None
+                    or self.speculative_config.method not in ("eagle", "eagle3")
+                )
+                and not self.is_pooling_model
+                and self.logits_processor is not None
+            ):
                 # last rank create real model output
                 if selected_token_indices is not None:
                     # aten::select -> adv_index -->
@@ -2913,8 +3266,7 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     # aten::index_select --> take -->
                     #     contrib_dynamic_take (tensor -> scalar)
                     hidden_states = hidden_states[:, selected_token_indices]
-                logits = self.compute_logits_model.compute_logits(
-                    hidden_states)
+                logits = self.compute_logits_model.compute_logits(hidden_states)
                 logits = logits.view(-1, logits.size(-1))
 
             # non last rank create intermediate tensors, bypass it
@@ -2933,7 +3285,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             self.drafter.load_model(self.model)
         if self.use_aux_hidden_state_outputs:
             self.model.set_aux_hidden_state_layers(
-                self.model.get_eagle3_aux_hidden_state_layers())
+                self.model.get_eagle3_aux_hidden_state_layers()
+            )
 
         # FIXME - device specific communication buffer (CUDA)?
         # disable communication buffer for RBLN (NYI)
@@ -2959,60 +3312,72 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             compiled_graph = self._compile_model(model_wrapper)
             self.model_executable = compiled_graph
 
-        distributed_executor_backend = \
+        distributed_executor_backend = (
             self.vllm_config.parallel_config.distributed_executor_backend
+        )
         if distributed_executor_backend == "ray":
             self._prepare_prefill_intermediate_tensors()
-            for batch_bucket_size \
-                in self.bucketing_manager.decode_batch_buckets:
+            for (
+                batch_bucket_size
+            ) in self.bucketing_manager.decode_batch_buckets:
                 self._prepare_decode_intermediate_tensors(batch_bucket_size)
         else:
             with torch.inference_mode():
                 self._prepare_prefill_intermediate_tensors()
-                for batch_bucket_size \
-                    in self.bucketing_manager.decode_batch_buckets:
-                    self._prepare_decode_intermediate_tensors(
-                        batch_bucket_size)
+                for (
+                    batch_bucket_size
+                ) in self.bucketing_manager.decode_batch_buckets:
+                    self._prepare_decode_intermediate_tensors(batch_bucket_size)
 
     def _prepare_prefill_intermediate_tensors(self) -> None:
-
         def _reshape(
-                batch_size: int, seq_len: int,
-                intermediate_tensors: IntermediateTensors
+            batch_size: int,
+            seq_len: int,
+            intermediate_tensors: IntermediateTensors,
         ) -> IntermediateTensors:
-            return IntermediateTensors({
-                k: v.view(batch_size, seq_len, -1)
-                for k, v in intermediate_tensors.items()
-            })
+            return IntermediateTensors(
+                {
+                    k: v.view(batch_size, seq_len, -1)
+                    for k, v in intermediate_tensors.items()
+                }
+            )
 
         batch_size = self.max_prefill_batch_size
         seq_len = self.max_num_batched_tokens
         self.prefill_intermediate_tensors = _reshape(
-            batch_size, seq_len,
+            batch_size,
+            seq_len,
             self.model.make_empty_intermediate_tensors(
                 batch_size=batch_size * seq_len,
                 dtype=self.model_config.dtype,
-                device=self.device))
+                device=self.device,
+            ),
+        )
 
     def _prepare_decode_intermediate_tensors(self, batch_bucket_size) -> None:
-
         def _reshape(
-                batch_size: int, seq_len: int,
-                intermediate_tensors: IntermediateTensors
+            batch_size: int,
+            seq_len: int,
+            intermediate_tensors: IntermediateTensors,
         ) -> IntermediateTensors:
-            return IntermediateTensors({
-                k: v.view(batch_size, seq_len, -1)
-                for k, v in intermediate_tensors.items()
-            })
+            return IntermediateTensors(
+                {
+                    k: v.view(batch_size, seq_len, -1)
+                    for k, v in intermediate_tensors.items()
+                }
+            )
 
         batch_size = batch_bucket_size
         seq_len = 1
         self.decode_intermediate_tensors[batch_bucket_size] = _reshape(
-            batch_size, seq_len,
+            batch_size,
+            seq_len,
             self.model.make_empty_intermediate_tensors(
                 batch_size=batch_size * seq_len,
                 dtype=self.model_config.dtype,
-                device=self.device))
+                device=self.device,
+            ),
+        )
 
     def save_tensorized_model(
         self,
@@ -3050,7 +3415,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             request = self.requests[req_id]
             num_prompt_tokens = len(request.prompt_token_ids)
             prompt_token_ids = torch.tensor(request.prompt_token_ids).to(
-                self.device, non_blocking=True)
+                self.device, non_blocking=True
+            )
 
             # Set up target LogprobsTensors object.
             logprobs_tensors = in_progress_dict.get(req_id)
@@ -3058,7 +3424,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 # Create empty logprobs CPU tensors for the entire prompt.
                 # If chunked, we'll copy in slice by slice.
                 logprobs_tensors = LogprobsTensors.empty_cpu(
-                    num_prompt_tokens - 1, num_prompt_logprobs + 1)
+                    num_prompt_tokens - 1, num_prompt_logprobs + 1
+                )
                 in_progress_dict[req_id] = logprobs_tensors
 
             # Determine number of logits to retrieve.
@@ -3088,27 +3455,31 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # then there is prompt logprob generated for each index.
             req_idx = self.input_batch.req_id_to_index[req_id]
             offset = self.query_start_loc.np[req_idx].item()
-            prompt_hidden_states = hidden_states[offset:offset + num_logits]
+            prompt_hidden_states = hidden_states[offset : offset + num_logits]
             logits = self.model.compute_logits(prompt_hidden_states)
 
             # Get the "target" tokens for each index. For prompt at index i,
             # the token at prompt index i+1 is the "sampled" token we want
             # to gather the logprob for.
-            tgt_token_ids = prompt_token_ids[start_tok:start_tok + num_logits]
+            tgt_token_ids = prompt_token_ids[start_tok : start_tok + num_logits]
 
             # Compute prompt logprobs.
             logprobs = self.sampler.compute_logprobs(logits)
             token_ids, logprobs, ranks = self.sampler.gather_logprobs(
-                logprobs, num_prompt_logprobs, tgt_token_ids)
+                logprobs, num_prompt_logprobs, tgt_token_ids
+            )
 
             # Transfer GPU->CPU async.
             chunk_slice = slice(start_idx, start_idx + num_logits)
             logprobs_tensors.logprob_token_ids[chunk_slice].copy_(
-                token_ids, non_blocking=True)
-            logprobs_tensors.logprobs[chunk_slice].copy_(logprobs,
-                                                         non_blocking=True)
+                token_ids, non_blocking=True
+            )
+            logprobs_tensors.logprobs[chunk_slice].copy_(
+                logprobs, non_blocking=True
+            )
             logprobs_tensors.selected_token_ranks[chunk_slice].copy_(
-                ranks, non_blocking=True)
+                ranks, non_blocking=True
+            )
 
         # Remove requests that have completed prefill from the batch
         # num_prompt_logprobs_dict.
@@ -3143,11 +3514,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     self.input_ids.gpu,
                     low=0,
                     high=self.model_config.get_vocab_size(),
-                    dtype=input_ids.dtype)
+                    dtype=input_ids.dtype,
+                )
 
             logger.debug_once("Randomizing dummy data for DP Rank")
-            input_ids.copy_(rand_input_ids()[:input_ids.size(0)],
-                            non_blocking=True)
+            input_ids.copy_(
+                rand_input_ids()[: input_ids.size(0)], non_blocking=True
+            )
             yield
             input_ids.fill_(0)
 
@@ -3155,8 +3528,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """
         Initialize the attention backends and attention metadata builders.
         """
-        assert len(self.attn_groups) == 0, \
+        assert len(self.attn_groups) == 0, (
             "Attention backends are already initialized"
+        )
 
         class AttentionGroupKey(NamedTuple):
             attn_backend: type[AttentionBackend]
@@ -3164,11 +3538,13 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         def get_attn_backends_for_group(
             kv_cache_group_spec: KVCacheGroupSpec,
-        ) -> tuple[dict[AttentionGroupKey, list[str]],
-                   set[type[AttentionBackend]]]:
+        ) -> tuple[
+            dict[AttentionGroupKey, list[str]], set[type[AttentionBackend]]
+        ]:
             layer_type = cast(type[Any], AttentionLayerBase)
             layers = get_layers_from_vllm_config(
-                self.vllm_config, layer_type, kv_cache_group_spec.layer_names)
+                self.vllm_config, layer_type, kv_cache_group_spec.layer_names
+            )
             attn_backends = {}
             attn_backend_layers = defaultdict(list)
             # Dedupe based on full class name; this is a bit safer than
@@ -3189,18 +3565,19 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 layer_kv_cache_spec = kv_cache_group_spec.kv_cache_spec
                 if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
                     layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[
-                        layer_name]
+                        layer_name
+                    ]
                 key = (full_cls_name, layer_kv_cache_spec)
-                attn_backends[key] = AttentionGroupKey(attn_backend,
-                                                       layer_kv_cache_spec)
+                attn_backends[key] = AttentionGroupKey(
+                    attn_backend, layer_kv_cache_spec
+                )
                 attn_backend_layers[key].append(layer_name)
             return (
-                {
-                    attn_backends[k]: v
-                    for k, v in attn_backend_layers.items()
-                },
-                set(group_key.attn_backend
-                    for group_key in attn_backends.values()),
+                {attn_backends[k]: v for k, v in attn_backend_layers.items()},
+                set(
+                    group_key.attn_backend
+                    for group_key in attn_backends.values()
+                ),
             )
 
         def create_attn_groups(
@@ -3208,8 +3585,10 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             kv_cache_group_id: int,
         ) -> list[AttentionGroup]:
             attn_groups: list[AttentionGroup] = []
-            for (attn_backend,
-                 kv_cache_spec), layer_names in attn_backends_map.items():
+            for (
+                attn_backend,
+                kv_cache_spec,
+            ), layer_names in attn_backends_map.items():
                 attn_group = AttentionGroup(
                     attn_backend,
                     layer_names,
@@ -3230,8 +3609,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         for i, attn_backend_map in enumerate(attention_backend_maps):
             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
 
-    def initialize_metadata_builders(self, kv_cache_config: KVCacheConfig,
-                                     kernel_block_sizes: list[int]) -> None:
+    def initialize_metadata_builders(
+        self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
+    ) -> None:
         """
         Create the metadata builders for all KV cache groups and attn groups.
         """
@@ -3241,9 +3621,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     self.vllm_config,
                     self.device,
                     kernel_block_sizes[kv_cache_group_id]
-                    if kv_cache_group_id < len(kernel_block_sizes) else None,
+                    if kv_cache_group_id < len(kernel_block_sizes)
+                    else None,
                     num_metadata_builders=1
-                    if not self.parallel_config.enable_dbo else 2,
+                    if not self.parallel_config.enable_dbo
+                    else 2,
                 )
         # Calculate reorder batch threshold (if needed)
         # Note (tdoublep): do this *after* constructing builders,
@@ -3262,8 +3644,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         pass
 
     @staticmethod
-    def select_common_block_size(kv_manager_block_size: int,
-                                 attn_groups: list[AttentionGroup]) -> int:
+    def select_common_block_size(
+        kv_manager_block_size: int, attn_groups: list[AttentionGroup]
+    ) -> int:
         """
         Select a block size that is supported by all backends and is a factor of
         kv_manager_block_size.
@@ -3282,15 +3665,17 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             ValueError: If no valid block size found
         """
 
-        def block_size_is_supported(backends: list[type[AttentionBackend]],
-                                    block_size: int) -> bool:
+        def block_size_is_supported(
+            backends: list[type[AttentionBackend]], block_size: int
+        ) -> bool:
             """
             Check if the block size is supported by all backends.
             """
             for backend in backends:
                 is_supported = False
-                for supported_size in backend.get_supported_kernel_block_sizes(
-                ):
+                for (
+                    supported_size
+                ) in backend.get_supported_kernel_block_sizes():
                     if isinstance(supported_size, int):
                         if block_size == supported_size:
                             is_supported = True
@@ -3299,7 +3684,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                             is_supported = True
                     else:
                         raise ValueError(
-                            f"Unknown supported size: {supported_size}")
+                            f"Unknown supported size: {supported_size}"
+                        )
                 if not is_supported:
                     return False
             return True
@@ -3323,9 +3709,11 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # kv_manager_block_size also satisfies MultipleOf(x_i) for all i.
         # We will return kv_manager_block_size in case 1.
         all_int_supported_sizes = set(
-            supported_size for backend in backends
+            supported_size
+            for backend in backends
             for supported_size in backend.get_supported_kernel_block_sizes()
-            if isinstance(supported_size, int))
+            if isinstance(supported_size, int)
+        )
 
         for supported_size in sorted(all_int_supported_sizes, reverse=True):
             if kv_manager_block_size % supported_size != 0:
@@ -3334,8 +3722,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 return supported_size
         raise ValueError(f"No common block size for {kv_manager_block_size}. ")
 
-    def may_reinitialize_input_batch(self, kv_cache_config: KVCacheConfig,
-                                     kernel_block_sizes: list[int]) -> None:
+    def may_reinitialize_input_batch(
+        self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
+    ) -> None:
         """
         Re-initialize the input batch if the block sizes are different from
         `[self.cache_config.block_size]`. This usually happens when there
@@ -3348,17 +3737,19 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         block_sizes = [
             kv_cache_group.kv_cache_spec.block_size
             for kv_cache_group in kv_cache_config.kv_cache_groups
-            if not isinstance(kv_cache_group.kv_cache_spec,
-                              EncoderOnlyAttentionSpec)
+            if not isinstance(
+                kv_cache_group.kv_cache_spec, EncoderOnlyAttentionSpec
+            )
         ]
 
         if block_sizes != [
-                self.cache_config.block_size
+            self.cache_config.block_size
         ] or kernel_block_sizes != [self.cache_config.block_size]:
             assert self.cache_config.cpu_offload_gb == 0, (
                 "Cannot re-initialize the input batch when CPU weight "
                 "offloading is enabled. See https://github.com/vllm-project/vllm/pull/18298 "  # noqa: E501
-                "for more details.")
+                "for more details."
+            )
             self.input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=max(self.max_model_len, self.max_encoder_len),
@@ -3373,11 +3764,14 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 is_pooling_model=self.is_pooling_model,
                 num_speculative_tokens=(
                     self.vllm_config.speculative_config.num_speculative_tokens
-                    if self.vllm_config.speculative_config else 0),
+                    if self.vllm_config.speculative_config
+                    else 0
+                ),
             )
 
     def _allocate_kv_cache_tensors(
-            self, kv_cache_config: KVCacheConfig) -> dict[str, torch.Tensor]:
+        self, kv_cache_config: KVCacheConfig
+    ) -> dict[str, torch.Tensor]:
         """
         Initializes the KV cache buffer with the correct size. The buffer needs
         to be reshaped to the desired shape before being used by the models.
@@ -3387,12 +3781,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Returns:
             dict[str, torch.Tensor]: A map between layer names to their
             corresponding memory buffer for KV cache.
-         """
+        """
         kv_cache_raw_tensors: dict[str, torch.Tensor] = {}
         for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
-            tensor = torch.zeros(kv_cache_tensor.size,
-                                 dtype=torch.int8,
-                                 device="meta")
+            tensor = torch.zeros(
+                kv_cache_tensor.size, dtype=torch.int8, device="cpu"
+            )
             for layer_name in kv_cache_tensor.shared_by:
                 kv_cache_raw_tensors[layer_name] = tensor
 
@@ -3402,8 +3796,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 if layer_name in self.runner_only_attn_layers:
                     continue
                 layer_names.add(layer_name)
-        assert layer_names == set(kv_cache_raw_tensors.keys(
-        )), "Some layers are not correctly initialized"
+        assert layer_names == set(kv_cache_raw_tensors.keys()), (
+            "Some layers are not correctly initialized"
+        )
         return kv_cache_raw_tensors
 
     def _attn_group_iterator(self) -> Iterator[AttentionGroup]:
@@ -3416,7 +3811,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             yield from attn_groups
 
     def _prepare_kernel_block_sizes(
-            self, kv_cache_config: KVCacheConfig) -> list[int]:
+        self, kv_cache_config: KVCacheConfig
+    ) -> list[int]:
         """
         Generate kernel_block_sizes that matches each block_size.
 
@@ -3432,13 +3828,15 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         """
         kernel_block_sizes = []
         for kv_cache_gid, kv_cache_group in enumerate(
-                kv_cache_config.kv_cache_groups):
+            kv_cache_config.kv_cache_groups
+        ):
             kv_cache_spec = kv_cache_group.kv_cache_spec
             if isinstance(kv_cache_spec, UniformTypeKVCacheSpecs):
                 # All layers in the UniformTypeKVCacheSpecs have the same type,
                 # Pick an arbitrary one to dispatch.
                 kv_cache_spec = next(
-                    iter(kv_cache_spec.kv_cache_specs.values()))
+                    iter(kv_cache_spec.kv_cache_specs.values())
+                )
             if isinstance(kv_cache_spec, EncoderOnlyAttentionSpec):
                 continue
             elif isinstance(kv_cache_spec, RBLNSlidingWindowSpec):
@@ -3450,7 +3848,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 attn_groups = self.attn_groups[kv_cache_gid]
                 kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
                 selected_kernel_size = self.select_common_block_size(
-                    kv_manager_block_size, attn_groups)
+                    kv_manager_block_size, attn_groups
+                )
                 kernel_block_sizes.append(selected_kernel_size)
             elif isinstance(kv_cache_spec, MambaSpec):
                 # This is likely Mamba or other non-attention cache,
@@ -3458,7 +3857,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                 kernel_block_sizes.append(kv_cache_spec.block_size)
             else:
                 raise NotImplementedError(
-                    f"unknown kv cache spec {kv_cache_group.kv_cache_spec}")
+                    f"unknown kv cache spec {kv_cache_group.kv_cache_spec}"
+                )
         return kernel_block_sizes
 
     def _reshape_kv_cache_tensors(
@@ -3493,12 +3893,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     continue
                 raw_tensor = kv_cache_raw_tensors[layer_name]
                 assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
-                num_blocks = (raw_tensor.numel() //
-                              kv_cache_spec.page_size_bytes)
+                num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
                 if isinstance(kv_cache_spec, AttentionSpec):
                     has_attn = True
-                    num_blocks_per_kv_block = (kv_cache_spec.block_size //
-                                               kernel_block_size)
+                    num_blocks_per_kv_block = (
+                        kv_cache_spec.block_size // kernel_block_size
+                    )
                     kernel_num_blocks = num_blocks * num_blocks_per_kv_block
 
                     kv_cache_shape = attn_backend.get_kv_cache_shape(
@@ -3510,39 +3910,45 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     )
                     dtype = kv_cache_spec.dtype
                     try:
-                        kv_cache_stride_order = \
+                        kv_cache_stride_order = (
                             attn_backend.get_kv_cache_stride_order()
-                        assert len(kv_cache_stride_order) == len(
-                            kv_cache_shape)
+                        )
+                        assert len(kv_cache_stride_order) == len(kv_cache_shape)
                     except (AttributeError, NotImplementedError):
                         kv_cache_stride_order = tuple(
-                            range(len(kv_cache_shape)))
+                            range(len(kv_cache_shape))
+                        )
                     # The allocation respects the backend-defined stride order
                     # to ensure the semantic remains consistent for each
                     # backend. We first obtain the generic kv cache shape and
                     # then permute it according to the stride order which could
                     # result in a non-contiguous tensor.
-                    kv_cache_shape = tuple(kv_cache_shape[i]
-                                           for i in kv_cache_stride_order)
+                    kv_cache_shape = tuple(
+                        kv_cache_shape[i] for i in kv_cache_stride_order
+                    )
                     # Maintain original KV shape view.
                     inv_order = [
                         kv_cache_stride_order.index(i)
                         for i in range(len(kv_cache_stride_order))
                     ]
-                    kv_caches[layer_name] = kv_cache_raw_tensors[
-                        layer_name].view(dtype).view(kv_cache_shape).permute(
-                            *inv_order)
+                    kv_caches[layer_name] = (
+                        kv_cache_raw_tensors[layer_name]
+                        .view(dtype)
+                        .view(kv_cache_shape)
+                        .permute(*inv_order)
+                    )
                 elif isinstance(kv_cache_spec, MambaSpec):
                     has_mamba = True
                     raw_tensor = kv_cache_raw_tensors[layer_name]
                     state_tensors = []
                     storage_offset_bytes = 0
-                    for (shape, dtype) in zip(kv_cache_spec.shapes,
-                                              kv_cache_spec.dtypes,
-                                              strict=False):
+                    for shape, dtype in zip(
+                        kv_cache_spec.shapes, kv_cache_spec.dtypes, strict=False
+                    ):
                         dtype_size = get_dtype_size(dtype)
                         num_element_per_page = (
-                            kv_cache_spec.page_size_bytes // dtype_size)
+                            kv_cache_spec.page_size_bytes // dtype_size
+                        )
                         target_shape = (num_blocks, *shape)
                         stride = torch.empty(target_shape).stride()
                         target_stride = (num_element_per_page, *stride[1:])
@@ -3566,8 +3972,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return kv_caches
 
     def initialize_kv_cache_tensors(
-            self, kv_cache_config: KVCacheConfig,
-            kernel_block_sizes: list[int]) -> dict[str, torch.Tensor]:
+        self, kv_cache_config: KVCacheConfig, kernel_block_sizes: list[int]
+    ) -> dict[str, torch.Tensor]:
         """
         Initialize the memory buffer for KV cache.
 
@@ -3590,29 +3996,37 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     cache_dtype,
                     self.device,
                     kernel_block_sizes,
-                ))
+                )
+            )
             self.cross_layers_kv_cache = cross_layers_kv_cache
             self.cross_layers_attn_backend = attn_backend
         else:
             # Fallback to the general case
             # Initialize the memory buffer for KV cache
             kv_cache_raw_tensors = self._allocate_kv_cache_tensors(
-                kv_cache_config)
+                kv_cache_config
+            )
 
             # Change the memory buffer to the desired shape
-            kv_caches = self._reshape_kv_cache_tensors(kv_cache_config,
-                                                       kv_cache_raw_tensors,
-                                                       kernel_block_sizes)
+            kv_caches = self._reshape_kv_cache_tensors(
+                kv_cache_config, kv_cache_raw_tensors, kernel_block_sizes
+            )
 
         # Set up cross-layer KV cache sharing
-        for layer_name, target_layer_name in self.shared_kv_cache_layers.items(
-        ):
-            logger.debug("%s reuses KV cache of %s", layer_name,
-                         target_layer_name)
+        for (
+            layer_name,
+            target_layer_name,
+        ) in self.shared_kv_cache_layers.items():
+            logger.debug(
+                "%s reuses KV cache of %s", layer_name, target_layer_name
+            )
             kv_caches[layer_name] = kv_caches[target_layer_name]
 
-        num_attn_module = (2 if self.model_config.hf_config.model_type
-                           == "longcat_flash" else 1)
+        num_attn_module = (
+            2
+            if self.model_config.hf_config.model_type == "longcat_flash"
+            else 1
+        )
         bind_kv_cache(
             kv_caches,
             self.compilation_config.static_forward_context,
@@ -3627,7 +4041,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         return kv_caches
 
     def maybe_add_kv_sharing_layers_to_kv_cache_groups(
-            self, kv_cache_config: KVCacheConfig) -> None:
+        self, kv_cache_config: KVCacheConfig
+    ) -> None:
         """
         Add layers that reuse KV cache to KV cache group of its target layer.
         Mapping of KV cache tensors happens in `initialize_kv_cache_tensors()`
@@ -3646,12 +4061,12 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             # In You Only Cache Once (https://arxiv.org/abs/2405.05254) or other
             # similar KV sharing setups, only the layers that generate KV caches
             # are involved in the prefill phase, enabling prefill to early exit.
-            attn_layers = get_layers_from_vllm_config(self.vllm_config,
-                                                      Attention)
+            attn_layers = get_layers_from_vllm_config(
+                self.vllm_config, Attention
+            )
             for layer_name in reversed(attn_layers):
                 if layer_name in self.shared_kv_cache_layers:
-                    self.kv_sharing_fast_prefill_eligible_layers.add(
-                        layer_name)
+                    self.kv_sharing_fast_prefill_eligible_layers.add(layer_name)
                 else:
                     break
 
@@ -3680,8 +4095,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
 
         # Reinitialize need to after initialize_attn_backend
         self.may_reinitialize_input_batch(kv_cache_config, kernel_block_sizes)
-        kv_caches = self.initialize_kv_cache_tensors(kv_cache_config,
-                                                     kernel_block_sizes)
+        kv_caches = self.initialize_kv_cache_tensors(
+            kv_cache_config, kernel_block_sizes
+        )
 
         if self.speculative_config and self.speculative_config.use_eagle():
             assert isinstance(self.drafter, EagleProposer)
@@ -3694,7 +4110,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
             if self.cross_layers_kv_cache is not None:
                 assert self.cross_layers_attn_backend is not None
                 kv_transfer_group.register_cross_layers_kv_cache(
-                    self.cross_layers_kv_cache, self.cross_layers_attn_backend)
+                    self.cross_layers_kv_cache, self.cross_layers_attn_backend
+                )
             else:
                 kv_transfer_group.register_kv_caches(kv_caches)
             kv_transfer_group.set_host_xfer_buffer_ops(copy_kv_blocks)
@@ -3710,7 +4127,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     "DCP requires attention impls to return"
                     " the softmax lse for decode, but the impl "
                     f"{layer_impl.__class__.__name__} "
-                    "does not return the softmax lse for decode.")
+                    "does not return the softmax lse for decode."
+                )
 
         self.cache_config.num_gpu_blocks = kv_cache_config.num_blocks
         self.cache_config.num_cpu_blocks = 0
@@ -3720,8 +4138,9 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         Add encoder-only layers to the KV cache config.
         """
         block_size = self.vllm_config.cache_config.block_size
-        encoder_only_attn_specs: dict[AttentionSpec,
-                                      list[str]] = defaultdict(list)
+        encoder_only_attn_specs: dict[AttentionSpec, list[str]] = defaultdict(
+            list
+        )
         attn_layers = get_layers_from_vllm_config(self.vllm_config, Attention)
         for layer_name, attn_module in attn_layers.items():
             if attn_module.attn_type == AttentionType.ENCODER_ONLY:
@@ -3729,16 +4148,18 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
                     block_size=block_size,
                     num_kv_heads=attn_module.num_kv_heads,
                     head_size=attn_module.head_size,
-                    dtype=self.kv_cache_dtype)
+                    dtype=self.kv_cache_dtype,
+                )
                 encoder_only_attn_specs[attn_spec].append(layer_name)
                 self.runner_only_attn_layers.add(layer_name)
         if len(encoder_only_attn_specs) > 0:
-            assert len(
-                encoder_only_attn_specs
-            ) == 1, "Only support one encoder-only attention spec now"
+            assert len(encoder_only_attn_specs) == 1, (
+                "Only support one encoder-only attention spec now"
+            )
             spec, layer_names = encoder_only_attn_specs.popitem()
             self.kv_cache_config.kv_cache_groups.append(
-                KVCacheGroupSpec(layer_names=layer_names, kv_cache_spec=spec))
+                KVCacheGroupSpec(layer_names=layer_names, kv_cache_spec=spec)
+            )
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         """
@@ -3753,7 +4174,8 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         attn_layers = get_layers_from_vllm_config(self.vllm_config, layer_type)
         for layer_name, attn_module in attn_layers.items():
             if isinstance(attn_module, Attention) and (
-                    kv_tgt_layer := attn_module.kv_sharing_target_layer_name):
+                kv_tgt_layer := attn_module.kv_sharing_target_layer_name
+            ):
                 # The layer doesn't need its own KV cache and will use that of
                 # the target layer. We skip creating a KVCacheSpec for it, so
                 # that KV cache management logic will act as this layer does
@@ -3778,20 +4200,26 @@ class RBLNModelRunner(LoRAModelRunnerMixin, KVConnectorModelRunnerMixin):
         # this is in the critical path of every single model
         # forward loop, this has caused perf issue for a disagg
         # setup.
-        pinned = self.sampled_token_ids_pinned_cpu[:sampled_token_ids.shape[0]]
+        pinned = self.sampled_token_ids_pinned_cpu[: sampled_token_ids.shape[0]]
         pinned.copy_(sampled_token_ids, non_blocking=True)
         # self.transfer_event.record()
         # self.transfer_event.synchronize()
         return pinned.tolist()
 
     def is_prefills(self) -> np.ndarray:
-        return (self.input_batch.num_computed_tokens_cpu
-                < self.input_batch.num_tokens_no_spec - 1)
+        return (
+            self.input_batch.num_computed_tokens_cpu
+            < self.input_batch.num_tokens_no_spec - 1
+        )
 
     def use_wrapped_compute_logits(self) -> bool:
-        return not (self.lora_config is not None or
-                    (self.speculative_config is not None and
-                     self.speculative_config.method in ("eagle", "eagle3")))
+        return not (
+            self.lora_config is not None
+            or (
+                self.speculative_config is not None
+                and self.speculative_config.method in ("eagle", "eagle3")
+            )
+        )
 
 
 def create_lora_mask(
@@ -3803,14 +4231,15 @@ def create_lora_mask(
     lora_dtype: torch.dtype,
     device: torch.device,
 ) -> torch.Tensor:
-    lora_mask = torch.zeros(input_ids.shape[0] * input_ids.shape[1],
-                            max_loras * max_lora_rank,
-                            dtype=lora_dtype,
-                            device=device)
-    ones = torch.ones(input_ids.shape[1],
-                      max_lora_rank,
-                      dtype=lora_dtype,
-                      device=device)
+    lora_mask = torch.zeros(
+        input_ids.shape[0] * input_ids.shape[1],
+        max_loras * max_lora_rank,
+        dtype=lora_dtype,
+        device=device,
+    )
+    ones = torch.ones(
+        input_ids.shape[1], max_lora_rank, dtype=lora_dtype, device=device
+    )
 
     for i in range(len(lora_ids)):
         if lora_ids[i] == 0:
@@ -3819,8 +4248,10 @@ def create_lora_mask(
         lora_index = lora_index_to_id.index(lora_ids[i])
         start_row = i * input_ids.shape[1]
         start_col = lora_index * max_lora_rank
-        lora_mask[start_row:start_row + input_ids.shape[1],
-                  start_col:start_col + max_lora_rank] = ones
+        lora_mask[
+            start_row : start_row + input_ids.shape[1],
+            start_col : start_col + max_lora_rank,
+        ] = ones
 
     return lora_mask
 
@@ -3834,21 +4265,24 @@ def create_sampler_indices_padded(
     device: torch.device,
 ) -> torch.Tensor:
     if is_prefill:
-        assert len(lora_ids
-                   ) == 1, "Only single LoRA is supported during prefill phase"
+        assert len(lora_ids) == 1, (
+            "Only single LoRA is supported during prefill phase"
+        )
 
     prompt_mapping: list[int] = [
         lora_index_to_id.index(lora_ids[i])
-        if i < len(lora_ids) and lora_ids[i] > 0 else -1
+        if i < len(lora_ids) and lora_ids[i] > 0
+        else -1
         for i in range(len(lora_ids) if is_prefill else max_num_seqs)
     ]
-    sampler_indices_padded = torch.tensor(prompt_mapping,
-                                          dtype=torch.long,
-                                          device=device)
-    sampler_indices_padded = torch.where(sampler_indices_padded == -1,
-                                         max_loras, sampler_indices_padded)
+    sampler_indices_padded = torch.tensor(
+        prompt_mapping, dtype=torch.long, device=device
+    )
+    sampler_indices_padded = torch.where(
+        sampler_indices_padded == -1, max_loras, sampler_indices_padded
+    )
     sampler_indices_padded = torch.arange(
-        0, len(sampler_indices_padded), dtype=torch.long,
-        device=device) + (sampler_indices_padded * len(sampler_indices_padded))
+        0, len(sampler_indices_padded), dtype=torch.long, device=device
+    ) + (sampler_indices_padded * len(sampler_indices_padded))
 
     return sampler_indices_padded

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -30,7 +30,8 @@ from vllm.model_executor import set_random_seed
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
-from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec, FullAttentionSpec
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        KVCacheSpec)
 from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput,
                              DraftTokenIds, ModelRunnerOutput)
 from vllm.v1.utils import report_usage_stats
@@ -38,6 +39,7 @@ from vllm.v1.worker.worker_base import WorkerBase
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
+from vllm_rbln.v1.worker.async_pp_communicator import AsyncPPCommunicator
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.worker.utils import get_maximum_num_blocks
 
@@ -110,6 +112,10 @@ class RBLNWorker(WorkerBase):
 
         self.parallel_config.disable_custom_all_reduce = True
 
+        # Async P2P for Chunked Pipeline Parallelism (CPP).
+        # Initialized lazily in init_device() once the PP group exists.
+        self._pp_communicator: AsyncPPCommunicator | None = None
+
     def sleep(self, level: int = 1) -> None:
         logger.warning("sleep mode is not supported on RBLN, ignore it.")
         pass
@@ -172,6 +178,21 @@ class RBLNWorker(WorkerBase):
         # Construct the model runner
         self.model_runner: RBLNModelRunner = RBLNModelRunner(
             self.vllm_config, self.device)
+
+        # Enable async P2P send for non-last PP ranks.
+        # The engine core's batch queue (size = pp_size) keeps multiple
+        # SchedulerOutputs in flight; async send lets this stage start the
+        # next batch while the blocking send_tensor_dict runs in the
+        # background thread.
+        pp_size = self.parallel_config.pipeline_parallel_size
+        if (pp_size > 1 and not get_pp_group().is_last_rank
+                and envs.VLLM_RBLN_ASYNC_PP_SEND):
+            self._pp_communicator = AsyncPPCommunicator(get_pp_group())
+            logger.info(
+                "Async PP send enabled (pp_size=%d, rank=%d)",
+                pp_size,
+                self.rank,
+            )
 
         if self.rank == 0:
             # If usage stat is enabled, collect relevant info.
@@ -261,7 +282,8 @@ class RBLNWorker(WorkerBase):
         num_gpu_blocks = min(
             int(max_num_blocks * self.cache_config.gpu_memory_utilization),
             max_required_num_blocks)
-        logger.info("max_num_blocks(%s), required_num_blocks(%s), num_blocks(%s)",
+        logger.info(
+            "max_num_blocks(%s), required_num_blocks(%s), num_blocks(%s)",
             max_num_blocks, max_required_num_blocks, num_gpu_blocks)
 
         if npu_num_blocks := os.environ.get("VLLM_RBLN_NPU_NUM_BLOCKS"):
@@ -319,6 +341,12 @@ class RBLNWorker(WorkerBase):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> Optional[ModelRunnerOutput]:
+        # CPP: ensure the previous async send completed before the model
+        # runner re-enters forward (which may reuse intermediate-tensor
+        # buffers).
+        if self._pp_communicator is not None:
+            self._pp_communicator.wait_pending_send()
+
         intermediate_tensors = None
         forward_pass = scheduler_output.total_num_scheduled_tokens > 0
         if forward_pass and not get_pp_group().is_first_rank:
@@ -336,8 +364,14 @@ class RBLNWorker(WorkerBase):
         assert parallel_config.distributed_executor_backend != (
             "external_launcher") and not get_pp_group().is_last_rank
 
-        # NOTE - DO NOT all_gather_group for RBLN pp
-        get_pp_group().send_tensor_dict(output.tensors)
+        # CPP: use async send so this worker can immediately start the
+        # next batch.  The background thread handles the blocking
+        # send_tensor_dict; we synchronise at the top of the next call.
+        if self._pp_communicator is not None:
+            self._pp_communicator.async_send_tensor_dict(output.tensors)
+        else:
+            # NOTE - DO NOT all_gather_group for RBLN pp
+            get_pp_group().send_tensor_dict(output.tensors)
         kv_connector_output = output.kv_connector_output
         if not kv_connector_output:
             return None
@@ -388,6 +422,8 @@ class RBLNWorker(WorkerBase):
 
     def shutdown(self) -> None:
         logger.info("v1 rbln_worker shutdown called")
+        if self._pp_communicator is not None:
+            self._pp_communicator.shutdown()
         if envs.VLLM_RBLN_METRICS:
             # FIXME - performance tracker atexit is not called
             self.model_runner.performance_tracker.print_final_stats()

--- a/vllm_rbln/v1/worker/rbln_worker.py
+++ b/vllm_rbln/v1/worker/rbln_worker.py
@@ -39,7 +39,6 @@ from vllm.v1.worker.worker_base import WorkerBase
 
 import vllm_rbln.rbln_envs as envs
 from vllm_rbln.logger import init_logger
-from vllm_rbln.v1.worker.async_pp_communicator import AsyncPPCommunicator
 from vllm_rbln.v1.worker.rbln_model_runner import RBLNModelRunner
 from vllm_rbln.worker.utils import estimate_available_memory
 
@@ -117,7 +116,7 @@ class RBLNWorker(WorkerBase):
 
         # Async P2P for Chunked Pipeline Parallelism (CPP).
         # Initialized lazily in init_device() once the PP group exists.
-        self._pp_communicator: AsyncPPCommunicator | None = None
+        self._pp_communicator = None
 
     def sleep(self, level: int = 1) -> None:
         logger.warning("sleep mode is not supported on RBLN, ignore it.")
@@ -187,12 +186,14 @@ class RBLNWorker(WorkerBase):
 
         # Enable async P2P send for non-last PP ranks.
         # The engine core's batch queue (size = pp_size) keeps multiple
-        # SchedulerOutputs in flight; async send lets this stage start the
-        # next batch while the blocking send_tensor_dict runs in the
-        # background thread.
+        # SchedulerOutputs in flight; async isend lets this stage start
+        # the next batch while tensor data transfers in the background.
         pp_size = self.parallel_config.pipeline_parallel_size
         if (pp_size > 1 and not get_pp_group().is_last_rank
                 and envs.VLLM_RBLN_ASYNC_PP_SEND):
+            from vllm_rbln.v1.worker.async_pp_communicator import (
+                AsyncPPCommunicator)
+
             self._pp_communicator = AsyncPPCommunicator(get_pp_group())
             logger.info(
                 "Async PP send enabled (pp_size=%d, rank=%d)",
@@ -324,9 +325,9 @@ class RBLNWorker(WorkerBase):
         self,
         scheduler_output: "SchedulerOutput",
     ) -> Optional[ModelRunnerOutput]:
-        # CPP: ensure the previous async send completed before the model
+        # CPP: ensure any previous isend() completed before the model
         # runner re-enters forward (which may reuse intermediate-tensor
-        # buffers).
+        # buffers).  No-op when no sends are pending.
         if self._pp_communicator is not None:
             self._pp_communicator.wait_pending_send()
 
@@ -344,12 +345,15 @@ class RBLNWorker(WorkerBase):
 
         assert isinstance(output, IntermediateTensors)
         parallel_config = self.vllm_config.parallel_config
-        assert (parallel_config.distributed_executor_backend
-                != ("external_launcher") and not get_pp_group().is_last_rank)
+        assert parallel_config.distributed_executor_backend != (
+            "external_launcher"
+        ), "external_launcher PP send is handled in rbln_model_runner"
+        assert not get_pp_group().is_last_rank, (
+            "last PP rank should return ModelRunnerOutput, "
+            "not IntermediateTensors")
 
-        # CPP: use async send so this worker can immediately start the
-        # next batch.  The background thread handles the blocking
-        # send_tensor_dict; we synchronise at the top of the next call.
+        # CPP: use isend so this worker can immediately start the next
+        # batch; we synchronise at the top of the next execute_model call.
         if self._pp_communicator is not None:
             self._pp_communicator.async_send_tensor_dict(output.tensors)
         else:


### PR DESCRIPTION
## Summary

V1 RBLN worker에 **Chunked Pipeline Parallelism (CPP)** 구현 — PP > 1 환경에서 chunked prefill과 파이프라인 병렬처리를 지원합니다.

### 주요 변경사항

- **`async_pp_communicator.py`** (신규): `torch.distributed.isend`를 사용한 비동기 P2P 전송
- **`rbln_worker.py`**: `AsyncPPCommunicator` 통합, `VLLM_RBLN_ASYNC_PP_SEND` 환경변수로 제어
- **`rbln_envs.py`**: `VLLM_RBLN_ASYNC_PP_SEND` 환경변수 추가
- **`rbln_model_runner.py`**: KV cache `device="meta"` → `device="cpu"` 버그 수정 + PP 관련 조정
- **`test_cpp.py`** (신규): correctness + benchmark 테스트 스크립트

Closes #5

---

## Implementation

### Wire protocol split

`send_tensor_dict`를 두 단계로 분리:

1. **Metadata (blocking)**: `send_object()`로 pickle-serialized 텐서 메타데이터 전송. 수신측이 버퍼 할당에 필요하므로 동기 전송 필수
2. **Tensor data (non-blocking)**: `torch.distributed.isend()`로 텐서 페이로드 전송. 다음 배치 계산과 오버랩 가능

### Correctness guarantee

핵심 불변식: intermediate-tensor 버퍼는 `isend` 진행 중 덮어쓰면 안 됨.

`wait_pending_send()`를 `execute_model()` 상단에서 호출 → 모델 러너가 forward 재진입 전에 이전 전송 완료 보장. 텐서 복사 불필요.

### Feature flag

```bash
VLLM_RBLN_ASYNC_PP_SEND=1   # Enable (default)
VLLM_RBLN_ASYNC_PP_SEND=0   # Disable (blocking send fallback)
```

---

## Benchmark Results

### 환경
- **Hardware**: 4x RBLN-CA25 (ATOM), 16GB DRAM per chip
- **Model**: `meta-llama/Llama-3.1-8B-Instruct` (BF16)
- **Config**: PP=4, TP=1, `max_num_seqs=8`, `chunk_size=128`, `block_size=1024`, `gpu_memory_utilization=0.8`

### PP=1 불가능

ATOM 단일 칩 = 16GB DRAM. Llama-3.1-8B BF16 모델 가중치 ~16GB → **단일 칩에 모델 로드 불가 (OOM)**. 이것이 PP가 필요한 핵심 이유.

> `VLLM_RBLN_TP_SIZE=4`로 단일 PP rank에 4칩 할당하면 PP=1으로 실행 가능하나, 이는 TP=4 PP=1 vs TP=1 PP=4 비교가 되어 PP 자체의 스케일링 효율 측정에 부적합.

### PP=4 결과 (Llama-3.1-8B-Instruct)

| Context | Requests | Input | Output | Total Time | Prefill | Decode | Total |
|---------|----------|-------|--------|------------|---------|--------|-------|
| Short (1K) | 32 | 1,024 | 128 | **62.02s** | 528 tok/s | 66 tok/s | **594 tok/s** |
| Long (32K) | 16 | 32,768 | 128 | **255.32s** | 2,053 tok/s | 8 tok/s | **2,061 tok/s** |

**Long context decode 처리량이 낮은 이유**: `max_batch_size = max_num_seqs // pp_size = 8 // 4 = 2` → 동시 decode 가능 시퀀스 2개, 각각 32K KV cache lookup 필요.

### Async P2P Send 효과 비교

| Metric | Async ON | Async OFF |
|--------|----------|-----------|
| Total time | 63.07s | 62.29s |
| Total throughput | 585 tok/s | 592 tok/s |

**결과: 무의미한 차이 (~1%).** 이유는 아래 분석 참조.

---

## 분석: Gloo 한계와 NPU-Direct P2P

### 현재 데이터 경로

```
[Stage N] NPU compute → CPU output tensor → gloo TCP/IP send → CPU tensor → NPU compute [Stage N+1]
```

**Gloo는 CPU-only 백엔드**. 모든 P2P 통신이 CPU 메모리와 TCP 소켓을 경유합니다.

확인된 사실:
- `rbln_worker.py:424` — `backend: str = "gloo"` 하드코딩
- `torch.distributed.is_nccl_available() = False` (NPU 서버에 NCCL 미설치)
- 커스텀 RBLN 분산 백엔드 없음
- `async_pp_communicator.py:115` — `isend`가 `cpu_group`에서 실행
- RBLN 컴파일된 모델은 output을 CPU로 반환 → 중간 텐서가 이미 CPU

`isend`(비동기)를 써도 **CPU 텐서의 TCP 전송**이므로, NPU 연산과의 오버랩 효과가 미미합니다.

### RBLN CCL의 현재 역할

`librbln-ccl.so`는 **컴파일러 수준의 Tensor Parallelism 전용**:

```
VLLM_RBLN_TP_SIZE=4 → 컴파일러가 모델을 4칩에 자동 분배 → RBLN CCL이 하드웨어 수준에서 all-reduce/all-gather
```

이는 **하나의 컴파일된 모델 내부** 통신이며, PP 스테이지 간 통신과는 별개.

### NPU-Direct P2P를 위한 3가지 옵션

#### Option 1: Custom torch.distributed Backend (ProcessGroupRBLN)

| 구성요소 | 설명 |
|----------|------|
| ProcessGroupRBLN C++ 클래스 | c10d::Backend 상속, send/recv/isend/irecv 구현 |
| RBLN P2P 프리미티브 | CCL 라이브러리에 P2P send/recv API 필요 |
| 디바이스 텐서 지원 | 중간 텐서가 NPU 메모리에 유지되어야 함 |
| Python 등록 | torch.distributed.register_backend("rbln", factory) |

참고 구현:
- **NVIDIA** ProcessGroupNCCL: `ncclSend(device_ptr, ...)` → GPU 메모리 직접 전송
- **Huawei** ProcessGroupHCCL: Ascend NPU 동일 패턴
- **Intel** ProcessGroupXCCL: PyTorch 2.8 네이티브

이상적인 데이터 경로:
```
[Stage N] NPU compute → NPU memory → RBLN CCL P2P → NPU memory → NPU compute [Stage N+1]
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                           CPU 경유 없음, 직접 디바이스간 전송
```

#### Option 2: RBLN CCL 직접 사용 (torch.distributed 우회)

torch.distributed를 우회하고 RBLN CCL의 P2P 프리미티브를 직접 호출:

```python
# 가상 코드 — RBLN CCL P2P API가 존재한다면
import rbln_ccl

def async_send_tensor(tensor_on_npu, dst_device_id):
    handle = rbln_ccl.isend(tensor_on_npu.data_ptr(), tensor_on_npu.numel(), dst_device_id)
    return handle  # non-blocking, NPU-to-NPU direct
```

장점: torch.distributed 인프라 의존성 없음, 구현 단순
단점: vLLM의 분산 추상화(GroupCoordinator)와의 호환성 유지 필요

#### Option 3: 컴파일러 수준 PP 통합 (장기)

RBLN 컴파일러가 PP도 TP처럼 처리:

```
현재: TP=4 → 컴파일러가 4칩에 모델 레이어 내부를 분배 + CCL 통신
미래: PP=4 → 컴파일러가 4칩에 레이어를 분배 + 스테이지 간 CCL 통신 + 파이프라인 스케줄링
```

PyTorch 수준의 PP 로직이 불필요해지며, RBLN 런타임이 전체 파이프라인을 제어.

### 선행 조건 (어떤 옵션이든)

1. **RBLN CCL에 P2P send/recv 지원**: 현재 collective ops (all-reduce/all-gather) 전용인지, P2P도 지원하는지 확인 필요
2. **디바이스 메모리 간 직접 전송 경로**: ATOM 칩간 PCIe P2P 또는 전용 인터커넥트 확인
3. **중간 텐서의 디바이스 상주**: 현재 RBLN 컴파일된 모델은 output을 CPU로 반환. NPU-direct P2P를 위해서는 중간 텐서가 NPU 메모리에 유지되어야 함

---

## Bug Fix: KV cache device="meta" → device="cpu"

PR #306에서 `_allocate_kv_cache_tensors`가 meta tensor로 변경되었으나, RBLN 컴파일 플로우에서 `rebel.mark_static_address(kv_cache)`가 실제 메모리 주소를 필요로 함. `device="cpu"`로 복원.

---

## Known Limitations

- `max_batch_size = max_num_seqs // pp_size` — PP=4에서 `max_num_seqs` 최소 4 이상 필요
- `batch_bucket_size=4`에서 컴파일러 버그 — decode 배치 버킷이 4가 되지 않도록 주의 (2 또는 8 사용)
- PP=1에서 8B 모델은 단일 ATOM 칩(16GB)에 로드 불가
- `VLLM_RBLN_BATCH_ATTN_OPT=1` 필수 (없으면 컴파일러 shape mismatch)

---

## 테스트 방법

```bash
export VLLM_RBLN_USE_VLLM_MODEL=1 VLLM_USE_V1=1 VLLM_RBLN_BATCH_ATTN_OPT=1
export HF_HUB_CACHE=/path/to/huggingface/cache

# Correctness test
python examples/experimental/test_cpp.py \
  --model meta-llama/Llama-3.1-8B-Instruct --pp 4 --correctness

# Short context benchmark
python examples/experimental/test_cpp.py \
  --model meta-llama/Llama-3.1-8B-Instruct --pp 4 \
  --max-model-len 2048 --max-num-seqs 8 --max-num-batched-tokens 128 \
  --benchmark --num-requests 32 --input-len 1024 --output-len 128

# Long context benchmark (32K)
python examples/experimental/test_cpp.py \
  --model meta-llama/Llama-3.1-8B-Instruct --pp 4 \
  --max-model-len 33024 --max-num-seqs 8 --max-num-batched-tokens 128 \
  --benchmark --num-requests 16 --input-len 32768 --output-len 128
```

## References

- [SGLang Chunked Pipeline Parallelism](https://lmsys.org/blog/2026-01-15-chunked-pipeline/)
- [vLLM PP overlap discussion (#18019)](https://github.com/vllm-project/vllm/issues/18019)
- [ProcessGroupNCCL — NVIDIA P2P reference](https://github.com/pytorch/pytorch/blob/main/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp)
- [ProcessGroupHCCL — Huawei Ascend NPU reference](https://github.com/Ascend/pytorch/blob/master/torch_npu/csrc/distributed/ProcessGroupHCCL.cpp)
